### PR TITLE
fix incorrect  xxMapper class name in example

### DIFF
--- a/packages/dart_mappable/README.md
+++ b/packages/dart_mappable/README.md
@@ -216,8 +216,8 @@ Here are again all **six** annotations that you can use in your code:
 class MyClass with MyClassMappable {
   ...
 
- static final fromMap = PersonMapper.fromMap;
- static final fromJson = PersonMapper.fromJson;
+ static final fromMap = MyClassMapper.fromMap;
+ static final fromJson = MyClassMapper.fromJson;
 }
 ```
 


### PR DESCRIPTION
This is a simple fix to one of the examples where PersonMapper was used instead of MyClassMapper (as the class name would dictate as well as the text leading up to the example).

```
Tip: If you prefer to use MyClass.fromJson over MyClassMapper.fromJson, add the fromJson and fromMap methods directly to your class like this:
```
