### PR TITLE
Fixes #135

### DIFF
--- a/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
+++ b/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
@@ -99,6 +99,8 @@ class MappableBuilder implements Builder {
         .format('// coverage:ignore-file\n'
             '// GENERATED CODE - DO NOT MODIFY BY HAND\n'
             '// ignore_for_file: type=lint\n'
+            '// ignore_for_file: strict_raw_type\n'
+            '// ignore_for_file: inference_failure_on_untyped_parameter\n'
             '// ignore_for_file: unused_element\n\n'
             'part of \'${p.basename(buildStep.inputId.uri.toString())}\';\n\n'
             '${output.join('\n\n')}\n' //,
@@ -141,6 +143,8 @@ class MappableBuilder implements Builder {
       '// coverage:ignore-file\n'
       '// GENERATED CODE - DO NOT MODIFY BY HAND\n'
       '// ignore_for_file: type=lint\n'
+      '// ignore_for_file: strict_raw_type\n'
+      '// ignore_for_file: inference_failure_on_untyped_parameter\n'
       '// ignore_for_file: unused_element\n\n'
       '${output.toString()}\n',
     );


### PR DESCRIPTION
#135 

When using 

```
analyzer:
  language:
    strict-casts: true
    strict-raw-types: true
    strict-inference: true
```

generated should include those lint ignores:

``
// ignore_for_file: strict_raw_type
// ignore_for_file: inference_failure_on_untyped_parameter
``

Because generic types are not mapped to Mapper and Mappable.