### PR TITLE
add the possibility to set a build_extensions option in the build.yaml

### DIFF
--- a/packages/dart_mappable/doc/configuration.md
+++ b/packages/dart_mappable/doc/configuration.md
@@ -81,6 +81,26 @@ global_options:
       generateMethods: [decode, encode, copy, stringify, equals]
 ```
 
+### `build_extensions`
+
+The `build_extensions` option allows you to specify custom paths for the generated files. This is particularly useful when working with certain code generation scenarios. It takes a map where keys are paths to source files and values are lists of corresponding generated file paths.
+
+#### Example:
+
+Here is an example to write in a build.yaml file to generate the generated files in a `generated` folder:
+```yaml
+targets:
+  $default:
+    builders:
+      # only to resolve build_runner conflicts
+      dart_mappable_builder:
+        options:
+          build_extensions:
+            'lib/{{path}}/{{file}}.dart':
+              - 'lib/{{path}}/generated/{{file}}.mapper.dart'
+              - 'lib/{{path}}/generated/{{file}}.init.dart'
+```
+
 ---
 
 <p align="right"><a href="../topics/Copy-With-topic.html">Next: Copy-With</a></p>

--- a/packages/dart_mappable_builder/lib/src/builder_options.dart
+++ b/packages/dart_mappable_builder/lib/src/builder_options.dart
@@ -3,6 +3,10 @@ import 'package:dart_mappable/dart_mappable.dart';
 
 import 'utils.dart';
 
+const _defaultExtensions = {
+  '.dart': ['.mapper.dart', '.init.dart']
+};
+
 /// The builder options for a specific library
 class MappableOptions {
   final CaseStyle? caseStyle;
@@ -13,6 +17,7 @@ class MappableOptions {
   final InitializerScope? initializerScope;
   final int? lineLength;
   final Map<String, String> renameMethods;
+  final Map<String, List<String>> buildExtensions;
 
   MappableOptions({
     this.caseStyle,
@@ -23,6 +28,7 @@ class MappableOptions {
     this.initializerScope,
     this.lineLength,
     this.renameMethods = const {},
+    this.buildExtensions = _defaultExtensions,
   });
 
   MappableOptions.parse(Map options)
@@ -36,7 +42,9 @@ class MappableOptions {
         initializerScope = null,
         lineLength =
             options['lineLength'] as int? ?? options['line_length'] as int?,
-        renameMethods = toMap(options['renameMethods'] ?? {});
+        renameMethods = toMap(options['renameMethods'] ?? {}),
+        buildExtensions =
+            validatedBuildExtensionsFrom(options, _defaultExtensions);
 
   MappableOptions apply(MappableOptions? options, {bool forceJoin = true}) {
     if (options == null) return this;

--- a/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
+++ b/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
@@ -50,9 +50,7 @@ class MappableBuilder implements Builder {
   }
 
   @override
-  Map<String, List<String>> get buildExtensions => const {
-        '.dart': ['.mapper.dart', '.init.dart']
-      };
+  Map<String, List<String>> get buildExtensions => options.buildExtensions;
 
   Future<MapperElementGroup> createMapperGroup(BuildStep buildStep) async {
     var entryLib = await buildStep.inputLibrary;
@@ -95,16 +93,17 @@ class MappableBuilder implements Builder {
 
     var output = await Future.wait(generators.map((g) => g.generate()));
 
+    final outputId = buildStep.allowedOutputs.first;
     var source = DartFormatter(pageWidth: options.lineLength ?? 80).format(
         '// coverage:ignore-file\n'
         '// GENERATED CODE - DO NOT MODIFY BY HAND\n'
         '// ignore_for_file: type=lint\n'
         '// ignore_for_file: unused_element, unnecessary_cast\n'
         '// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter\n\n'
-        'part of \'${p.basename(buildStep.inputId.uri.toString())}\';\n\n'
+        'part of \'${uriOfPartial(buildStep.inputId, outputId)}\';\n\n'
         '${output.join('\n\n')}\n' //,
         );
-    var outputId = buildStep.inputId.changeExtension('.mapper.dart');
+
     await buildStep.writeAsString(outputId, source);
   }
 
@@ -138,6 +137,7 @@ class MappableBuilder implements Builder {
 
     output.write('}');
 
+    final outputId = buildStep.allowedOutputs.last;
     var source = DartFormatter(pageWidth: options.lineLength ?? 80).format(
       '// coverage:ignore-file\n'
       '// GENERATED CODE - DO NOT MODIFY BY HAND\n'
@@ -146,7 +146,6 @@ class MappableBuilder implements Builder {
       '${output.toString()}\n',
     );
 
-    var outputId = buildStep.inputId.changeExtension('.init.dart');
     await buildStep.writeAsString(outputId, source);
   }
 }

--- a/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
+++ b/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
@@ -122,9 +122,12 @@ class MappableBuilder implements Builder {
 
     discovered.sortBy((e) => e.key.source.uri.toString());
 
+    final outputId = buildStep.allowedOutputs.last;
+
     output.write(writeImports(
       buildStep.inputId,
       discovered.map((e) => e.key.source.uri).toList(),
+      outputId.path,
     ));
 
     output.write('void initializeMappers() {\n');
@@ -137,7 +140,6 @@ class MappableBuilder implements Builder {
 
     output.write('}');
 
-    final outputId = buildStep.allowedOutputs.last;
     var source = DartFormatter(pageWidth: options.lineLength ?? 80).format(
       '// coverage:ignore-file\n'
       '// GENERATED CODE - DO NOT MODIFY BY HAND\n'
@@ -150,7 +152,7 @@ class MappableBuilder implements Builder {
   }
 }
 
-String writeImports(AssetId input, List<Uri> imports) {
+String writeImports(AssetId input, List<Uri> imports, String outputDirectory) {
   List<String> package = [], relative = [];
   var prefixes = <String, int?>{};
 
@@ -193,5 +195,6 @@ String writeImports(AssetId input, List<Uri> imports) {
       ? '${s.map((s) => "import '$s'${prefixes[s] != null ? ' as p${prefixes[s]}' : ''};").join('\n')}\n\n'
       : '';
 
-  return joined(package) + joined(relative);
+  return joined(package) +
+      joined(relative.map((r) => p.join(outputDirectory, r)).toList());
 }

--- a/packages/dart_mappable_builder/lib/src/utils.dart
+++ b/packages/dart_mappable_builder/lib/src/utils.dart
@@ -214,33 +214,3 @@ Map<String, List<String>> validatedBuildExtensionsFrom(
   }
   return result;
 }
-
-String uriOfPartial(AssetId source, AssetId output) {
-  assert(source.package == output.package);
-  String sourcePath = source.path;
-  String outputPath = output.path;
-
-  // Split the paths into individual segments.
-  List<String> sourceSegments = sourcePath.split('/');
-  List<String> outputSegments = outputPath.split('/');
-
-  // Find the common prefix between source and output paths.
-  int commonIndex = 0;
-  for (int i = 0; i < sourceSegments.length && i < outputSegments.length; i++) {
-    if (sourceSegments[i] != outputSegments[i]) {
-      break;
-    }
-    commonIndex = i;
-  }
-
-  // Calculate the relative path.
-  List<String> relativeSegments = List.generate(
-    outputSegments.length - commonIndex - 2,
-    (_) => '..',
-  );
-  relativeSegments.addAll(sourceSegments.sublist(commonIndex + 1));
-
-  // Join the segments to form the relative path.
-  String relativePath = relativeSegments.join('/');
-  return relativePath;
-}

--- a/packages/dart_mappable_builder/test/simple_model_test.dart
+++ b/packages/dart_mappable_builder/test/simple_model_test.dart
@@ -1,5 +1,3 @@
-import 'package:build/build.dart';
-import 'package:dart_mappable_builder/src/utils.dart';
 import 'package:test/test.dart';
 
 import 'utils/test_mappable.dart';
@@ -33,22 +31,5 @@ void main() {
         },
       );
     });
-
-    test('uriOfPartial', () {
-      AssetId input = AssetId('package', 'lib/models/model.dart');
-      AssetId output = AssetId('package',
-          'lib/models/subfolder1/subfolder2/subfolder3/model.mapper.dart');
-      expect(uriOfPartial(input, output), '../../../model.dart');
-      expect(uriOfPartial(output, input),
-          'subfolder1/subfolder2/subfolder3/model.mapper.dart');
-
-      //add test for default path
-      input = AssetId('package', 'lib/model.dart');
-      output = AssetId('package', 'lib/model.mapper.dart');
-      expect(uriOfPartial(input, output), 'model.dart');
-      expect(uriOfPartial(output, input), 'model.mapper.dart');
-    });
-
-
   });
 }

--- a/packages/dart_mappable_builder/test/simple_model_test.dart
+++ b/packages/dart_mappable_builder/test/simple_model_test.dart
@@ -1,3 +1,5 @@
+import 'package:build/build.dart';
+import 'package:dart_mappable_builder/src/utils.dart';
 import 'package:test/test.dart';
 
 import 'utils/test_mappable.dart';
@@ -30,6 +32,15 @@ void main() {
               equals({'a': 'hi', 'b': 1, 'c': null, 'd': false}),
         },
       );
+    });
+
+    test('uriOfPartial', () {
+      AssetId input = AssetId('package', 'lib/models/model.dart');
+      AssetId output = AssetId('package',
+          'lib/models/subfolder1/subfolder2/subfolder3/model.mapper.dart');
+      expect(uriOfPartial(input, output), '../../../model.dart');
+      expect(uriOfPartial(output, input),
+          'subfolder1/subfolder2/subfolder3/model.mapper.dart');
     });
   });
 }

--- a/packages/dart_mappable_builder/test/simple_model_test.dart
+++ b/packages/dart_mappable_builder/test/simple_model_test.dart
@@ -41,6 +41,14 @@ void main() {
       expect(uriOfPartial(input, output), '../../../model.dart');
       expect(uriOfPartial(output, input),
           'subfolder1/subfolder2/subfolder3/model.mapper.dart');
+
+      //add test for default path
+      input = AssetId('package', 'lib/model.dart');
+      output = AssetId('package', 'lib/model.mapper.dart');
+      expect(uriOfPartial(input, output), 'model.dart');
+      expect(uriOfPartial(output, input), 'model.mapper.dart');
     });
+
+
   });
 }


### PR DESCRIPTION
We can now add a ```yaml
options:
  build_extensions:
    'lib/{{path}}/{{file}}.dart': ['lib/{{path}}/generated/{{file}}.mapper.dart', 'lib/{{path}}/generated/{{file}}.init.dart']```
To a build.yaml to specify where to put the built files.
I did not find any mappableContainer in the exemples so I'm not shure that it works perfectly for the mappablecontainer. For the others generation, it works like a charm.