### PR TITLE
Buggy generated code when className contain $

### DIFF
--- a/packages/dart_mappable_builder/lib/src/generators/class_mapper_generator.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/class_mapper_generator.dart
@@ -22,6 +22,10 @@ class ClassMapperGenerator extends MapperGenerator<TargetClassMapperElement>
         ToStringMixin {
   ClassMapperGenerator(super.element);
 
+  String escapeText(String text) {
+    return text.replaceAll('\$', '\\\$').replaceAll("(?<!\\)'", "\\'");
+  }
+
   @override
   Future<String> generate() async {
     var output = StringBuffer();
@@ -36,7 +40,7 @@ class ClassMapperGenerator extends MapperGenerator<TargetClassMapperElement>
 
     output.write('\n'
         '  @override\n'
-        "  final String id = '${element.uniqueId}';\n");
+        "  final String id = '${escapeText(element.uniqueId)}';\n");
 
     if (element.typeParamsList.isNotEmpty) {
       generateTypeFactory(output);


### PR DESCRIPTION
Hi @schultek,

I found a bug when you try to generate code for a class that contains a $ in the name. 

In fact, for example, the `Foo$Bar` class will generate a `Foo$BarMapper` class containing the following string of code 

```dart
final String id = 'Foo$Bar';
```
which obviously does not compile or if it compiles (if Bar has been defined) it doesn't work as expected.

The following PR simply escapes the string containing the id.