### PR TITLE
add unordered equality check for iterables

### DIFF
--- a/packages/dart_mappable/CHANGELOG.md
+++ b/packages/dart_mappable/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added unordered equality for check Iterables
+
 # 4.0.1
 
 - Added support for generic typed parameters for deep copyWith.

--- a/packages/dart_mappable/lib/src/mapper_container.dart
+++ b/packages/dart_mappable/lib/src/mapper_container.dart
@@ -403,6 +403,9 @@ class _MapperContainerBase implements MapperContainer, TypeProvider {
     if (value == null) {
       return other == null;
     }
+    if (value is Iterable && other is Iterable) {
+      return const UnorderedIterableEquality().equals(value, other);
+    }
     var mapper = _mapperFor(value);
     if (mapper != null) {
       return mapper.isValueEqual(value, other, this);


### PR DESCRIPTION
When comparing objects that have a list as parameter, the package does not account for unordered lists. 

Now:
```
final a = MyMappableClass(myList: [1, 2, 3]);
final b = MyMappableClass(myList: [3, 1, 2]);

assert(a == b) // fail
```
This results in a false negative even though the lists contains the same elements. Checking for unordered equality is a pattern that we use in our project and i think it makes sense to be the default behavior.

After:
```
final a = MyMappableClass(myList: [1, 2, 3]);
final b = MyMappableClass(myList: [3, 1, 2]);

assert(a == b) // pass
```

What are your thoughts on this?