### PR TITLE
add 'dartCompatible' option to MappableClass

### DIFF
--- a/packages/dart_mappable/doc/configuration.md
+++ b/packages/dart_mappable/doc/configuration.md
@@ -79,6 +79,8 @@ global_options:
       discriminatorKey: type
       # used to specify which methods to generate (all by default)
       generateMethods: [decode, encode, copy, stringify, equals]
+      # determines name of to/fromJson and to/fromMap methods
+      dartCompatible: false
 ```
 
 ### `build_extensions`

--- a/packages/dart_mappable/lib/src/annotations.dart
+++ b/packages/dart_mappable/lib/src/annotations.dart
@@ -18,6 +18,7 @@ class MappableClass extends MappableInterface {
     this.discriminatorValue,
     super.hook,
     super.generateMethods,
+    super.dartCompatible,
     this.includeSubClasses,
     super.includeCustomMappers,
   }) : super._();
@@ -148,6 +149,7 @@ class MappableRecord extends MappableInterface {
     super.uniqueId,
     super.hook,
     super.includeCustomMappers,
+    super.dartCompatible,
   }) : super._();
 }
 
@@ -161,6 +163,7 @@ abstract class MappableInterface {
     this.uniqueId,
     this.hook,
     this.generateMethods,
+    this.dartCompatible,
     this.includeCustomMappers,
   });
 
@@ -190,6 +193,20 @@ abstract class MappableInterface {
   /// using the `|` operator.
   final int? generateMethods;
 
+  /// Affects to/fromJson and to/fromMap methods
+  ///
+  /// Defaults to false, which is backwards-compatible with dart_mappable
+  /// to/fromJson converts to/from String, and to/fromMap converts to/from Map
+  ///
+  /// However this differs from the standard Dart API where
+  /// to/fromJson converts to/from Map
+  ///
+  /// When 'true', methods will be to/fromJson (works with Maps)
+  /// and serialize/deserialize (works with Strings)
+  ///
+  /// see this issue for more information: https://github.com/schultek/dart_mappable/issues/82
+  final bool? dartCompatible;
+
   /// Specify additional custom mappers that should be included for fields
   /// of this class.
   final Iterable<MapperBase>? includeCustomMappers;
@@ -207,6 +224,7 @@ class MappableLib {
     this.ignoreNull,
     this.discriminatorKey,
     this.generateMethods,
+    this.dartCompatible,
     this.generateInitializerForScope,
   });
 
@@ -224,6 +242,9 @@ class MappableLib {
 
   /// Specify which methods to generate for classes.
   final int? generateMethods;
+
+  /// Specify what to name to/fromJson and to/fromMap methods.
+  final bool? dartCompatible;
 
   /// Will generated a new <filename>.init.dart file with an initializer
   /// method that automatically registers all mappers in the scope.

--- a/packages/dart_mappable/test/dart_compatible/dart_compatible_test.dart
+++ b/packages/dart_mappable/test/dart_compatible/dart_compatible_test.dart
@@ -1,0 +1,67 @@
+import 'package:dart_mappable/dart_mappable.dart';
+import 'package:test/test.dart';
+
+part 'dart_compatible_test.mapper.dart';
+
+
+@MappableClass(dartCompatible: true)
+class A with AMappable {
+  final String a;
+  A(this.a);
+}
+
+@MappableClass(dartCompatible: false)
+class B with BMappable {
+  final String b;
+  B(this.b);
+}
+
+void main() {
+  group('Dart compatible', () {
+    test('serializing with dart compatible method names', () {
+      AMapper.ensureInitialized();
+      var a = A('test');
+      BMapper.ensureInitialized();
+      var b = B('test');
+
+      // should work
+      expect(a.toJson(), equals({'a': 'test'}));
+      expect(a.serialize(), equals('{"a":"test"}'));
+      expect(b.toMap(), equals({'b': 'test'}));
+      expect(b.toJson(), equals('{"b":"test"}'));
+
+      // toJson() returns different types
+      expect(a.toJson(), TypeMatcher<Map>());
+      expect(b.toJson(), TypeMatcher<String>());
+
+      expect(a.serialize(), TypeMatcher<String>());
+      expect(b.toMap(), TypeMatcher<Map>());
+
+    });
+
+    test('deserializing with dart compatible method names', () {
+      AMapper.ensureInitialized();
+      String aString = '{"a":"test"}';
+      Map<String, String> aMap = {'a': 'test'};
+      A a = A('test');
+      BMapper.ensureInitialized();
+      String bString = '{"b":"test"}';
+      Map<String, String> bMap = {'b': 'test'};
+      B b = B('test');
+
+      // should work
+      expect(AMapper.fromJson(aMap), equals(a));
+      expect(AMapper.deserialize(aString), equals(a));
+      expect(BMapper.fromMap(bMap), equals(b));
+      expect(BMapper.fromJson(bString), equals(b));
+
+      // fromJson() accepts different types
+      expect(AMapper.fromJson(aMap), TypeMatcher<A>());
+      expect(BMapper.fromJson(bString), TypeMatcher<B>());
+
+      expect(AMapper.deserialize(aString), TypeMatcher<A>());
+      expect(BMapper.fromMap(bMap), TypeMatcher<B>());
+
+    });
+  });
+}

--- a/packages/dart_mappable_builder/lib/src/builder_options.dart
+++ b/packages/dart_mappable_builder/lib/src/builder_options.dart
@@ -14,6 +14,7 @@ class MappableOptions {
   final bool? ignoreNull;
   final String? discriminatorKey;
   final int? generateMethods;
+  final bool? dartCompatible;
   final InitializerScope? initializerScope;
   final int? lineLength;
   final Map<String, String> renameMethods;
@@ -25,6 +26,7 @@ class MappableOptions {
     this.ignoreNull,
     this.discriminatorKey,
     this.generateMethods,
+    this.dartCompatible,
     this.initializerScope,
     this.lineLength,
     this.renameMethods = const {},
@@ -39,6 +41,7 @@ class MappableOptions {
         discriminatorKey = options['discriminatorKey'] as String?,
         generateMethods =
             parseGenerateMethods(toList(options['generateMethods'])),
+        dartCompatible = options['dartCompatible'] as bool?,
         initializerScope = null,
         lineLength =
             options['lineLength'] as int? ?? options['line_length'] as int?,
@@ -55,6 +58,7 @@ class MappableOptions {
       ignoreNull: options.ignoreNull ?? ignoreNull,
       discriminatorKey: options.discriminatorKey ?? discriminatorKey,
       generateMethods: options.generateMethods ?? generateMethods,
+      dartCompatible: options.dartCompatible ?? dartCompatible,
       initializerScope: options.initializerScope ?? initializerScope,
       renameMethods: {...renameMethods, ...options.renameMethods},
     );
@@ -68,6 +72,7 @@ class MappableOptions {
       ignoreNull: object.read('ignoreNull')?.toBoolValue(),
       discriminatorKey: object.read('discriminatorKey')?.toStringValue(),
       generateMethods: object.read('generateMethods')?.toIntValue(),
+      dartCompatible: object.read('dartCompatible')?.toBoolValue(),
       initializerScope: initScope?.isNull ?? true
           ? null
           : InitializerScope

--- a/packages/dart_mappable_builder/lib/src/elements/class/class_mapper_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/class/class_mapper_element.dart
@@ -69,6 +69,12 @@ abstract class ClassMapperElement extends InterfaceMapperElement<ClassElement>
           options.generateMethods ??
           GenerateMethods.all;
 
+  late final bool dartCompatible =
+      annotation.value?.read('dartCompatible')?.toBoolValue() ??
+          options.dartCompatible ??
+          superElement?.dartCompatible ??
+          false;
+
   late final String? hookForClass = () {
     var hook = annotation.value?.read('hook');
     if (hook != null && !hook.isNull) {

--- a/packages/dart_mappable_builder/lib/src/elements/record/record_mapper_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/record/record_mapper_element.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 
+import '../../utils.dart';
 import '../mapper_element.dart';
 
 abstract class RecordMapperElement<T extends Element>
@@ -43,4 +44,9 @@ abstract class RecordMapperElement<T extends Element>
   String genericArgAt(int index) {
     return String.fromCharCode('A'.codeUnitAt(0) + index);
   }
+
+  late final bool dartCompatible =
+      annotation.value?.read('dartCompatible')?.toBoolValue() ??
+          options.dartCompatible ??
+          false;
 }

--- a/packages/dart_mappable_builder/lib/src/generators/mixins/decoding_mixin.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/mixins/decoding_mixin.dart
@@ -111,8 +111,10 @@ mixin DecodingMixin on MapperGenerator<TargetClassMapperElement> {
       return;
     }
 
-    var fromJsonName = element.options.renameMethods['fromJson'] ?? 'fromJson';
-    var fromMapName = element.options.renameMethods['fromMap'] ?? 'fromMap';
+    var fromJsonName =
+        element.options.renameMethods['fromJson'] ?? (element.dartCompatible ? 'deserialize' : 'fromJson');
+    var fromMapName =
+        element.options.renameMethods['fromMap'] ?? (element.dartCompatible ? 'fromJson' : 'fromMap');
 
     output.write('\n'
         '  static ${element.prefixedDecodingClassName}${element.typeParams} $fromMapName${element.typeParamsDeclaration}(Map<String, dynamic> map) {\n'

--- a/packages/dart_mappable_builder/lib/src/generators/mixins/encoding_mixin.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/mixins/encoding_mixin.dart
@@ -4,8 +4,10 @@ import '../../elements/class/target_class_mapper_element.dart';
 import '../generator.dart';
 
 mixin EncodingMixin on MapperGenerator<TargetClassMapperElement> {
-  late final toJsonName = element.options.renameMethods['toJson'] ?? 'toJson';
-  late final toMapName = element.options.renameMethods['toMap'] ?? 'toMap';
+  late final toJsonName =
+      element.options.renameMethods['toJson'] ?? (element.dartCompatible ? 'serialize' : 'toJson');
+  late final toMapName =
+      element.options.renameMethods['toMap'] ?? (element.dartCompatible ? 'toJson' : 'toMap');
 
   void generateEncoderMixin(StringBuffer output) {
     if (!element.shouldGenerate(GenerateMethods.encode)) {

--- a/packages/dart_mappable_builder/lib/src/generators/record_mapper_generator.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/record_mapper_generator.dart
@@ -107,8 +107,10 @@ class RecordMapperGenerator extends MapperGenerator<RecordMapperElement> {
   }
 
   void generateStaticDecoders(StringBuffer output) {
-    var fromJsonName = element.options.renameMethods['fromJson'] ?? 'fromJson';
-    var fromMapName = element.options.renameMethods['fromMap'] ?? 'fromMap';
+    var fromJsonName =
+        element.options.renameMethods['fromJson'] ?? (element.dartCompatible ? 'deserialize' : 'fromJson');
+    var fromMapName =
+        element.options.renameMethods['fromMap'] ?? (element.dartCompatible ? 'fromJson' : 'fromMap');
 
     output.write('\n'
         '  static ${element.className}${element.typeParams} $fromMapName${element.typeParamsDeclaration}(Map<String, dynamic> map) {\n'


### PR DESCRIPTION
This is an attempt to address #82. Unfortunately most other Dart libraries that involve serialization automatically expect `toJson()`/`fromJson()` methods to return/accept a `Map`, rather than a `String`. I prefer `dart_mappable`'s naming convention, however, as was mentioned in that thread, the Dart convention is widespread.

This adds a `dartCompatible` option to `MappableClass` and to the `globalOptions` that, when `true`, will rename the methods. Note that if someone uses the `renameMethods` options, those will take priority. **The biggest advantage of this PR is the ability to customize Dart compatibility on each individual class.** `dartCompatible` is `false` by default so it will not break any compatibility unless you specifically turn it on.

The renaming policy is:
```
toMap() -> toJson()
toJson() -> serialize()
fromMap() -> fromJson()
fromJson() -> deserialize()
```
There is also a test group demonstrating a class annotated with `dartCompatible: true` compared to the default. (I did not write tests for the global option or for Records)

Of course, an alternate philosophy is to decide that going forward, this package should aim for widespread Dart compatibility. One could rename all the generated methods to comply, and require a `legacy: true` option in order to preserve the current naming convention. This would break compatibility, but easily fixed via
```
global_options:
  dart_mappable_builder:
    options:
      legacy: true
```
A PR that followed this concept would be basically the same PR but with every boolean flipped.