### PR TITLE
Added support for per-field custom mappers

### DIFF
--- a/packages/dart_mappable/lib/src/annotations.dart
+++ b/packages/dart_mappable/lib/src/annotations.dart
@@ -122,20 +122,25 @@ class MappableConstructor {
   const MappableConstructor();
 }
 
-/// Used to annotate a parameter or field to overwrite the mapped key.
+/// Used to annotate a parameter or field to overwrite the mapped key or the
+/// mapper used for that field.
 ///
 /// {@category Models}
 /// {@category Records}
 /// {@category Configuration}
 /// {@category Mapping Hooks}
+/// {@category Custom Mappers}
 class MappableField {
-  const MappableField({this.key, this.hook});
+  const MappableField({this.key, this.hook, this.customMapper});
 
   /// Use this key instead of the field name.
   final String? key;
 
   /// Define custom hooks used only for this field.
   final MappingHook? hook;
+
+  /// Specify a custom mapper that should be used for this field.
+  final MapperBase? customMapper;
 }
 
 /// Used to annotate a record in order to generate mapping code.

--- a/packages/dart_mappable/lib/src/mapper_container.dart
+++ b/packages/dart_mappable/lib/src/mapper_container.dart
@@ -167,10 +167,10 @@ abstract class MapperContainer {
   String asString(dynamic value);
 
   /// Adds a new mapper to the set of mappers this container holds.
-  void use<T extends Object>(MapperBase<T> mapper);
+  void use<T>(MapperBase<T> mapper);
 
   /// Removes the mapper for type [T] this container currently holds.
-  MapperBase<T>? unuse<T extends Object>();
+  MapperBase<T>? unuse<T>();
 
   /// Adds a list of mappers to the set of mappers this container holds.
   void useAll(Iterable<MapperBase> mappers);
@@ -494,10 +494,10 @@ class _MapperContainerBase implements MapperContainer, TypeProvider {
   }
 
   @override
-  void use<T extends Object>(MapperBase<T> mapper) => useAll([mapper]);
+  void use<T>(MapperBase<T> mapper) => useAll([mapper]);
 
   @override
-  MapperBase<T>? unuse<T extends Object>() {
+  MapperBase<T>? unuse<T>() {
     var mapper = _mappers.remove(T.base) as MapperBase<T>?;
     _invalidateCachedMappers();
     return mapper;

--- a/packages/dart_mappable/lib/src/mapper_utils.dart
+++ b/packages/dart_mappable/lib/src/mapper_utils.dart
@@ -79,7 +79,7 @@ extension TypeCheck<T> on T {
   }
 }
 
-extension MapperUtils<T extends Object> on MapperBase<T> {
+extension MapperUtils<T> on MapperBase<T> {
   bool isValueEqual(T? value, Object? other, [MapperContainer? container]) {
     if (value == null) {
       return other == null;

--- a/packages/dart_mappable/lib/src/mappers/interface_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/interface_mapper.dart
@@ -71,7 +71,8 @@ class Field<T extends Object, V> {
     if (data != null) {
       options = options?.copyWith(data: data) ?? EncodingOptions(data: data);
     }
-    if (customMapper != null && customMapper!.isForType(T)) {
+    final v = get(value);
+    if (customMapper != null && customMapper!.isFor(v)) {
       try {
         if (hook != null) {
           value = hook!.beforeEncode(value) as T;
@@ -88,11 +89,11 @@ class Field<T extends Object, V> {
       }
     } else {
       if (arg == null) {
-        result = context.$enc<V>(get(value), name, options, hook);
+        result = context.$enc<V>(v, name, options, hook);
       } else {
         result = context.callWith(
           arg!,
-          <U>() => context.$enc<U>(get(value), name, options, hook),
+          <U>() => context.$enc<U>(v, name, options, hook),
         );
       }
     }
@@ -101,16 +102,16 @@ class Field<T extends Object, V> {
 
   R decode<R>(Map<String, dynamic> value, DecodingContext context) {
     DecodingOptions? options;
-    R? result;
     if (data != null) {
       options = DecodingOptions(data: data);
     }
-    if (customMapper != null && customMapper!.isForType(R)) {
+    var result = value[key];
+    if (customMapper != null && customMapper!.isFor(result)) {
       try {
         if (hook != null) {
-          value = hook!.beforeDecode(value) as Map<String, dynamic>;
+          result = hook!.beforeDecode(result) as Map<String, dynamic>;
         }
-        result = customMapper!.decoder(value[key] as Object, context) as R?;
+        result = customMapper!.decoder(result as Object, context) as R?;
         if (hook != null) {
           result = hook!.afterDecode(result) as R?;
         }
@@ -122,10 +123,10 @@ class Field<T extends Object, V> {
       }
     } else {
       result = opt || def != null
-          ? context.$dec<R?>(value[key], key, hook, options)
-          : context.$dec<R>(value[key], key, hook, options);
+          ? context.$dec<R?>(result, key, hook, options)
+          : context.$dec<R>(result, key, hook, options);
     }
-    return result ?? (def as R);
+    return result as R ?? (def as R);
   }
 }
 

--- a/packages/dart_mappable/lib/src/mappers/mapper_base.dart
+++ b/packages/dart_mappable/lib/src/mappers/mapper_base.dart
@@ -10,7 +10,7 @@ import 'mapping_context.dart';
 /// It defaults to throwing unsupported exceptions for all methods.
 ///
 /// {@category Custom Mappers}
-abstract class MapperBase<T extends Object> {
+abstract class MapperBase<T> {
   const MapperBase();
 
   /// A unique id for this type, defaults to the name of the type.

--- a/packages/dart_mappable/pubspec.yaml
+++ b/packages/dart_mappable/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_mappable
 description: Improved json serialization and data classes with full support for generics, inheritance, customization and more.
-version: 4.2.0
+version: 4.2.1
 repository: https://github.com/schultek/dart_mappable
 issue_tracker: https://github.com/schultek/dart_mappable/issues
 documentation: https://pub.dev/documentation/dart_mappable/latest/topics/Introduction-topic.html
@@ -23,6 +23,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
-  dart_mappable_builder: ^4.2.0
+  # dart_mappable_builder: ^4.2.1
+  dart_mappable_builder:
+    path: ../dart_mappable_builder
   lints: '>=1.0.0 <3.0.0'
   test: ^1.20.1

--- a/packages/dart_mappable/pubspec.yaml
+++ b/packages/dart_mappable/pubspec.yaml
@@ -23,8 +23,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
-  # dart_mappable_builder: ^4.2.1
-  dart_mappable_builder:
-    path: ../dart_mappable_builder
+  dart_mappable_builder: ^4.2.1
   lints: '>=1.0.0 <3.0.0'
   test: ^1.20.1

--- a/packages/dart_mappable_builder/lib/src/elements/field/class_mapper_field_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/field/class_mapper_field_element.dart
@@ -131,6 +131,13 @@ class ClassMapperFieldElement extends MapperFieldElement {
         (await hookFor(field?.getter));
     return hook != null ? ', hook: $hook' : '';
   }();
+
+  @override
+  late final Future<String> customMapper = () async {
+    final customMapper =
+        (await customMapperFor(field) ?? await customMapperFor(field?.getter));
+    return customMapper != null ? ', customMapper: $customMapper' : '';
+  }();
 }
 
 String? _keyFor(Element? element) {

--- a/packages/dart_mappable_builder/lib/src/elements/field/mapper_field_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/field/mapper_field_element.dart
@@ -30,7 +30,24 @@ abstract class MapperFieldElement {
 
   String get arg;
 
+  Future<String> get customMapper;
+
   Future<String> get hook;
+}
+
+Future<String?> customMapperFor(Element? element) async {
+  if (element == null) return null;
+  if (fieldChecker.hasAnnotationOf(element)) {
+    final node = await getResolvedAnnotationNode(
+      element,
+      MappableField,
+      'customMapper',
+    );
+    if (node != null) {
+      return node.toSource();
+    }
+  }
+  return null;
 }
 
 Future<String?> hookFor(Element? element) async {

--- a/packages/dart_mappable_builder/lib/src/elements/field/record_mapper_field_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/field/record_mapper_field_element.dart
@@ -79,4 +79,10 @@ class RecordMapperFieldElement extends MapperFieldElement {
     var hook = await param.getHook();
     return hook != null ? ', hook: $hook' : '';
   }();
+
+  @override
+  late final Future<String> customMapper = () async {
+    var customMapper = await param.getCustomMapper();
+    return customMapper != null ? ', customMapper: $customMapper' : '';
+  }();
 }

--- a/packages/dart_mappable_builder/lib/src/elements/param/record_mapper_param_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/param/record_mapper_param_element.dart
@@ -20,6 +20,15 @@ class RecordMapperParamElement extends MapperParamElement {
 
   bool get isGeneric => typeArg != null;
 
+  Future<String?> getCustomMapper() async {
+    final node = getAnnotationProperty(
+      param,
+      MappableField,
+      'customMapper',
+    );
+    return node?.toSource();
+  }
+
   @override
   Future<String?> getHook() async {
     var node = getAnnotationProperty(param, MappableField, 'hook');

--- a/packages/dart_mappable_builder/lib/src/generators/extensions/fields_extension.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/extensions/fields_extension.dart
@@ -16,7 +16,7 @@ extension FieldsExtension<T extends InterfaceMapperElement>
             '  static dynamic _arg\$${f.name}${element.typeParamsDeclaration}(f) => f<${f.argType}>();\n');
       }
       output.write(
-          "  static const Field<${element.prefixedClassName}, ${f.staticArgType}> _f\$${f.name} = Field('${f.name.replaceAll(r'$', r'\$')}', ${f.getter}${f.key}${f.mode}${f.opt}${await f.def}${f.arg}${await f.hook});\n");
+          "  static const Field<${element.prefixedClassName}, ${f.staticArgType}> _f\$${f.name} = Field('${f.name.replaceAll(r'$', r'\$')}', ${f.getter}${f.key}${f.mode}${f.opt}${await f.def}${f.arg}${await f.hook}${await f.customMapper});\n");
     }
 
     output.write(

--- a/packages/dart_mappable_builder/pubspec.yaml
+++ b/packages/dart_mappable_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_mappable_builder
 description: Improved json serialization and data classes with full support for generics, inheritance, customization and more.
-version: 4.2.0
+version: 4.2.1
 repository: https://github.com/schultek/dart_mappable
 issue_tracker: https://github.com/schultek/dart_mappable/issues
 funding:

--- a/packages/dart_mappable_builder/pubspec.yaml
+++ b/packages/dart_mappable_builder/pubspec.yaml
@@ -14,7 +14,9 @@ dependencies:
   ansicolor: ^2.0.1
   build: ^2.0.0
   collection: ^1.15.0
-  dart_mappable: ^4.2.0
+  # dart_mappable: ^4.2.1
+  dart_mappable:
+    path: ../dart_mappable
   dart_style: ^2.2.4
   glob: ^2.1.0
   path: ^1.8.0

--- a/packages/dart_mappable_builder/pubspec.yaml
+++ b/packages/dart_mappable_builder/pubspec.yaml
@@ -14,9 +14,7 @@ dependencies:
   ansicolor: ^2.0.1
   build: ^2.0.0
   collection: ^1.15.0
-  # dart_mappable: ^4.2.1
-  dart_mappable:
-    path: ../dart_mappable
+  dart_mappable: ^4.2.1
   dart_style: ^2.2.4
   glob: ^2.1.0
   path: ^1.8.0


### PR DESCRIPTION
The changes allow for per-field custom mappers, this is helpful in the case someone (like me) needs to use multiple mappers for fields of the same type.

An example of this is strict APIs with different date and time formats that can exist in the same model. Below you'll find an example of how it can be used.

```dart
import 'package:dart_mappable/dart_mappable.dart';
import 'package:intl/intl.dart';

final _dateFormat = DateFormat('yyyy-MM-dd');
final _dateWithTimeFormat = DateFormat('yyyy-MM-dd HH:mm');

class DateMapper extends SimpleMapper<DateTime> {
  const DateMapper();

  @override
  DateTime decode(dynamic value) {
    return _dateFormat.parse(value as String);
  }

  @override
  dynamic encode(DateTime self) {
    return _dateFormat.format(self);
  }
}

class DateWithTimeMapper extends SimpleMapper<DateTime> {
  const DateWithTimeMapper();

  @override
  DateTime decode(dynamic value) {
    return _dateWithTimeFormat.parse(value as String);
  }

  @override
  dynamic encode(DateTime self) {
    return _dateWithTimeFormat.format(self);
  }
}

@MappableClass()
class MyClass with MyClassMappable {
  @MappableField(customMapper: DateMapper())
  final DateTime dateOnly;

  @MappableField(customMapper: DateWithTimeMapper())
  final DateTime dateWithTime;

  const MyClass({
    required this.dateOnly,
    required this.dateWithTime,
  });
}
```

I also pumped both package versions to ```4.2.1```.

Thanks for the amazing package.