### PR TITLE
Add CaseStyle.upperSnakeCase

### DIFF
--- a/packages/dart_mappable/lib/src/case_style.dart
+++ b/packages/dart_mappable/lib/src/case_style.dart
@@ -89,6 +89,9 @@ class CaseStyle {
 
   /// Transforms to 'FIELDNAME'
   static const upperCase = CaseStyle(tail: TextTransform.upperCase);
+
+  /// Transforms to 'FIELD_NAME'
+  static const upperSnakeCase = CaseStyle(tail: TextTransform.upperCase, separator: '_');
 }
 
 extension CaseStyleTransform on CaseStyle? {


### PR DESCRIPTION
Adds the "upper snake case" (commonly known as `CONSTANT_CASE` or `SCREAMING_SNAKE_CASE` in Rust).

It is commonly used within the JVM ecosystem.