### PR TITLE
fix library path on windows

### DIFF
--- a/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
+++ b/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
@@ -96,7 +96,8 @@ class MappableBuilder implements Builder {
     final outputId = buildStep.allowedOutputs.first;
 
     var libraryPath = p.posix
-        .relative(buildStep.inputId.path, from: p.dirname(outputId.path));
+        .relative(buildStep.inputId.path, from: p.dirname(outputId.path))
+        .replaceAll('\\', '/');
     var source = DartFormatter(pageWidth: options.lineLength ?? 80).format(
         '// coverage:ignore-file\n'
         '// GENERATED CODE - DO NOT MODIFY BY HAND\n'


### PR DESCRIPTION
replaces backlashes with forward slashes in the library path
fixes #192 