### PR TITLE
feat: allow exclude fields from toJson and toMap

### DIFF
--- a/packages/dart_mappable/lib/src/annotations.dart
+++ b/packages/dart_mappable/lib/src/annotations.dart
@@ -13,6 +13,7 @@ class MappableClass extends MappableInterface {
   const MappableClass({
     super.caseStyle,
     super.ignoreNull,
+    this.ignore,
     super.uniqueId,
     this.discriminatorKey,
     this.discriminatorValue,
@@ -43,6 +44,9 @@ class MappableClass extends MappableInterface {
 
   /// To be used with [discriminatorValue] to signal a default subclass.
   static const useAsDefault = MappingFlags.useAsDefault;
+
+  /// Property keys to exclude from `toMap` and `toJson`.
+  final Iterable<String>? ignore;
 }
 
 /// Collection of flags used for annotations.

--- a/packages/dart_mappable/lib/src/mappers/class_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/class_mapper.dart
@@ -200,8 +200,13 @@ abstract class ClassMapperBase<T extends Object>
 
   @override
   Object? encode(T value, EncodingContext context) {
-    var result =
-        InterfaceMapperBase.encodeFields(value, _params, ignoreNull, context);
+    var result = InterfaceMapperBase.encodeFields(
+      value,
+      _params,
+      ignoreNull,
+      ignore,
+      context,
+    );
     if (_encodedStaticParams != null) {
       return {...result, ...?_encodedStaticParams};
     }

--- a/packages/dart_mappable/lib/src/mappers/record_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/record_mapper.dart
@@ -26,8 +26,13 @@ abstract class RecordMapperBase<T extends Record> extends InterfaceMapperBase<T>
 
   @override
   Object? encode(T value, EncodingContext context) {
-    return InterfaceMapperBase.encodeFields(value, fields.values, ignoreNull,
-        context.change(args: () => apply(context)));
+    return InterfaceMapperBase.encodeFields(
+      value,
+      fields.values,
+      ignoreNull,
+      ignore,
+      context.change(args: () => apply(context)),
+    );
   }
 
   @override


### PR DESCRIPTION
Please find this PR to allow exclude fields from toJson and toMap.
I used the same logic as ignoreNull.

You will be able to add `ignore: ['key1', 'key2']`on `MappableClass`

I will need help for managing the tests.

Related to: #105 