### PR TITLE
Directly pass args instead of using closure

### DIFF
--- a/packages/dart_mappable/lib/src/mapper_container.dart
+++ b/packages/dart_mappable/lib/src/mapper_container.dart
@@ -476,11 +476,9 @@ class _MapperContainerBase implements MapperContainer, TypeProvider {
             value,
             MappingContext(
               container: this,
-              args: () {
-                return value.runtimeType.args
-                    .map((t) => t == UnresolvedType ? dynamic : t)
-                    .toList();
-              },
+              args: value.runtimeType.args
+                  .map((t) => t == UnresolvedType ? dynamic : t)
+                  .toList(),
             ));
       } catch (e, stacktrace) {
         Error.throwWithStackTrace(

--- a/packages/dart_mappable/lib/src/mappers/mapper_base.dart
+++ b/packages/dart_mappable/lib/src/mappers/mapper_base.dart
@@ -44,7 +44,7 @@ abstract class MapperBase<T extends Object> {
         value,
         DecodingContext(
           container: container,
-          args: () => type.args,
+          args: type.args,
           options: options,
         ),
       ) as V;
@@ -81,7 +81,7 @@ abstract class MapperBase<T extends Object> {
               typeArgs = fallback;
             }
             return typeArgs.toList();
-          },
+          }(),
         ),
       );
 
@@ -121,7 +121,7 @@ abstract class MapperBase<T extends Object> {
       if (!isFor(other)) return false;
       var context = MappingContext(
         container: container,
-        args: () => value.runtimeType.args
+        args: value.runtimeType.args
             .map((t) => t == UnresolvedType ? dynamic : t)
             .toList(),
       );
@@ -143,7 +143,7 @@ abstract class MapperBase<T extends Object> {
     try {
       var context = MappingContext(
         container: container,
-        args: () => value.runtimeType.args
+        args: value.runtimeType.args
             .map((t) => t == UnresolvedType ? dynamic : t)
             .toList(),
       );
@@ -165,7 +165,7 @@ abstract class MapperBase<T extends Object> {
     try {
       var context = MappingContext(
         container: container,
-        args: () => value.runtimeType.args
+        args: value.runtimeType.args
             .map((t) => t == UnresolvedType ? dynamic : t)
             .toList(),
       );

--- a/packages/dart_mappable/lib/src/mappers/mapping_context.dart
+++ b/packages/dart_mappable/lib/src/mappers/mapping_context.dart
@@ -7,14 +7,10 @@ class MappingContext {
   /// The container that is used for this mapping call.
   final MapperContainer container;
 
-  /// A list of type arguments to get the concrete type for a generic mapper.
-  final List<Type> Function()? _args;
+  final List<Type> args;
 
-  late final List<Type> args = _args?.call() ?? [];
-
-  MappingContext({MapperContainer? container, List<Type> Function()? args})
-      : _args = args,
-        container = container ?? MapperContainer.globals;
+  MappingContext({MapperContainer? container, this.args = const []})
+      : container = container ?? MapperContainer.globals;
 
   Type arg(int index, [List<int> argIndices = const []]) {
     var a = args[index];
@@ -38,19 +34,16 @@ class DecodingContext extends MappingContext {
   final bool inherited;
 
   DecodingContext change(
-      {MapperContainer? container,
-      List<Type> Function()? args,
-      bool? inherited}) {
+      {MapperContainer? container, List<Type>? args, bool? inherited}) {
     return DecodingContext(
       container: container ?? this.container,
-      args: args ?? _args,
+      args: args ?? this.args,
       options: options,
       inherited: inherited ?? this.inherited,
     );
   }
 
-  DecodingContext inherit(
-      {MapperContainer? container, List<Type> Function()? args}) {
+  DecodingContext inherit({MapperContainer? container, List<Type>? args}) {
     return change(container: container, args: args, inherited: true);
   }
 }
@@ -61,11 +54,10 @@ class EncodingContext extends MappingContext {
 
   final EncodingOptions? options;
 
-  EncodingContext change(
-      {MapperContainer? container, List<Type> Function()? args}) {
+  EncodingContext change({MapperContainer? container, List<Type>? args}) {
     return EncodingContext(
       container: container ?? this.container,
-      args: args ?? _args,
+      args: args ?? this.args,
       options: options,
     );
   }

--- a/packages/dart_mappable/lib/src/mappers/record_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/record_mapper.dart
@@ -21,19 +21,19 @@ abstract class RecordMapperBase<T extends Record> extends InterfaceMapperBase<T>
 
   @override
   T decode(Object? value, DecodingContext context) {
-    return super.decode(value, context.change(args: () => apply(context)));
+    return super.decode(value, context.change(args: apply(context)));
   }
 
   @override
   Object? encode(T value, EncodingContext context) {
-    return InterfaceMapperBase.encodeFields(value, fields.values, ignoreNull,
-        context.change(args: () => apply(context)));
+    return InterfaceMapperBase.encodeFields(
+        value, fields.values, ignoreNull, context.change(args: apply(context)));
   }
 
   @override
   bool isForType(Type type) {
     try {
-      var newArgs = apply(DecodingContext(args: () => type.args));
+      var newArgs = apply(DecodingContext(args: type.args));
       var instantiatedType = typeFactory
           .callWith(parameters: [<T>() => T], typeArguments: newArgs);
       return type == instantiatedType;

--- a/packages/dart_mappable/test/copy_with/copy_with_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/copy_with_test.mapper.dart
@@ -520,7 +520,7 @@ class BrandListMapper extends SubClassMapperBase<BrandList> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(args: () => []);
+    return context.inherit(args: []);
   }
 
   static BrandList _instantiate(DecodingData data) {
@@ -778,7 +778,7 @@ class KeyedItemListMapper extends SubClassMapperBase<KeyedItemList> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(args: () => [dynamic, context.arg(0)]);
+    return context.inherit(args: [dynamic, context.arg(0)]);
   }
 
   static KeyedItemList<K, T> _instantiate<K, T>(DecodingData data) {

--- a/packages/dart_mappable/test/generics/generics_change_test.mapper.dart
+++ b/packages/dart_mappable/test/generics/generics_change_test.mapper.dart
@@ -331,7 +331,7 @@ class DMapper extends SubClassMapperBase<D> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(args: () => [dynamic, context.arg(0)]);
+    return context.inherit(args: [dynamic, context.arg(0)]);
   }
 
   static D<T, V> _instantiate<T, V>(DecodingData data) {
@@ -436,11 +436,10 @@ class EMapper extends SubClassMapperBase<E> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(
-        args: () => [
-              context.arg(1, [0]),
-              context.arg(0)
-            ]);
+    return context.inherit(args: [
+      context.arg(1, [0]),
+      context.arg(0)
+    ]);
   }
 
   static E<T, V> _instantiate<T, V>(DecodingData data) {
@@ -542,7 +541,7 @@ class FMapper extends SubClassMapperBase<F> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(args: () => []);
+    return context.inherit(args: []);
   }
 
   static F _instantiate(DecodingData data) {
@@ -646,11 +645,10 @@ class GMapper extends SubClassMapperBase<G> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(
-        args: () => [
-              context.arg(0),
-              context.type(<$A>() => A<$A>, [context.arg(0)])
-            ]);
+    return context.inherit(args: [
+      context.arg(0),
+      context.type(<$A>() => A<$A>, [context.arg(0)])
+    ]);
   }
 
   static G<T, V> _instantiate<T, V extends A<T>>(DecodingData data) {
@@ -757,7 +755,7 @@ class HMapper extends SubClassMapperBase<H> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(args: () => [C<num>]);
+    return context.inherit(args: [C<num>]);
   }
 
   static H<T> _instantiate<T extends C<num>>(DecodingData data) {
@@ -865,11 +863,10 @@ class IMapper extends SubClassMapperBase<I> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(
-        args: () => [
-              context.type(<$A extends num>() => C<$A>, [context.arg(0)]),
-              context.arg(0)
-            ]);
+    return context.inherit(args: [
+      context.type(<$A extends num>() => C<$A>, [context.arg(0)]),
+      context.arg(0)
+    ]);
   }
 
   static I<T, V> _instantiate<T extends C<V>, V extends num>(
@@ -979,13 +976,12 @@ class JMapper extends SubClassMapperBase<J> {
 
   @override
   DecodingContext inherit(DecodingContext context) {
-    return context.inherit(
-        args: () => [
-              context.type(<$A extends $B, $B extends num>() => C<$A>,
-                  [context.arg(0), context.arg(1)]),
-              context.arg(0),
-              context.arg(1)
-            ]);
+    return context.inherit(args: [
+      context.type(<$A extends $B, $B extends num>() => C<$A>,
+          [context.arg(0), context.arg(1)]),
+      context.arg(0),
+      context.arg(1)
+    ]);
   }
 
   static J<T, V, U> _instantiate<T extends C<V>, V extends U, U extends num>(


### PR DESCRIPTION
The closure is causing issues in Dart transpiled to JS. Not sure why, but directly passing the args fixes the issue. Not sure why args is a closure either. All tests pass with this change.