### PR TITLE
Static function to build a map of fields declared in specific class

### DIFF
--- a/packages/dart_mappable_builder/lib/src/generators/class_mapper_generator.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/class_mapper_generator.dart
@@ -65,6 +65,7 @@ class ClassMapperGenerator extends MapperGenerator<TargetClassMapperElement>
     await generateInstantiateMethod(output);
 
     generateStaticDecoders(output);
+    generateDeclaredFieldEncoder(output);
     output.write('}\n\n');
 
     if (element.generateAsMixin) {


### PR DESCRIPTION
Implements #298 
Admittedly my naive understanding of what variations in the object-model this function could encounter... but let me know what else it needs...

This is an example of the output after this commit...

```
  static Map<String, dynamic> toDeclaredFieldsMap(
      {required String breed}) {
    var mapper = DogMapper.ensureInitialized();
    return {
      _f$breed.name: mapper.encodeValue(breed)
    };
  }
```