### PR TITLE
Add JSON Schema generation support for dart_mappable models via new subpackage

### DIFF
--- a/packages/dart_mappable/example/lib/main.mapper.dart
+++ b/packages/dart_mappable/example/lib/main.mapper.dart
@@ -47,6 +47,10 @@ class BrandMapper extends EnumMapper<Brand> {
         return 'BMW';
     }
   }
+
+  @override
+  Map<String, Brand> get enums =>
+      {"Toyota": Brand.Toyota, "Audi": Brand.Audi, "BMW": Brand.BMW};
 }
 
 extension BrandMapperExtension on Brand {

--- a/packages/dart_mappable/lib/src/mapper_container.dart
+++ b/packages/dart_mappable/lib/src/mapper_container.dart
@@ -142,7 +142,7 @@ abstract class MapperContainer {
   /// Encodes a value to a map.
   ///
   /// This is a typed wrapper around the [toValue] method.
-  Map<String, dynamic> toMap<T>(T object);
+  Map<dynamic, dynamic> toMap<T>(T object);
 
   /// Decodes an iterable to a given type [T].
   ///
@@ -364,7 +364,7 @@ class _MapperContainerBase implements MapperContainer, TypeProvider {
     }
 
     var type = options?.type ?? T;
-    if (value is Map<String, dynamic> &&
+    if (value is Map<dynamic, dynamic> &&
         value[MapperContainer.typeIdKey] != null) {
       type = TypePlus.fromId(value[MapperContainer.typeIdKey] as String);
       if (type == UnresolvedType) {
@@ -405,12 +405,12 @@ class _MapperContainerBase implements MapperContainer, TypeProvider {
   }
 
   @override
-  T fromMap<T>(Map<String, dynamic> map) => fromValue<T>(map);
+  T fromMap<T>(Map<dynamic, dynamic> map) => fromValue<T>(map);
 
   @override
-  Map<String, dynamic> toMap<T>(T object) {
+  Map<dynamic, dynamic> toMap<T>(T object) {
     var value = toValue<T>(object);
-    if (value is Map<String, dynamic>) {
+    if (value is Map<dynamic, dynamic>) {
       return value;
     } else {
       throw MapperException.incorrectEncoding(

--- a/packages/dart_mappable/lib/src/mappers/class_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/class_mapper.dart
@@ -14,12 +14,12 @@ abstract class SubClassMapperBase<T extends Object> extends ClassMapperBase<T> {
   dynamic get discriminatorValue;
   ClassMapperBase get superMapper;
 
-  bool canDecode(Map<String, dynamic> value) {
+  bool canDecode(Map<dynamic, dynamic> value) {
     var discriminator = discriminatorValue;
     if (identical(discriminator, MappingFlags.useAsDefault)) {
       return true;
     } else if (discriminator is Function) {
-      if (discriminator is bool Function(Map<String, dynamic>)) {
+      if (discriminator is bool Function(Map<dynamic, dynamic>)) {
         return discriminator(value);
       } else {
         throw AssertionError(
@@ -171,7 +171,7 @@ abstract class ClassMapperBase<T extends Object>
 
   @override
   T decode(Object? value, DecodingContext context) {
-    var map = value.checked<Map<String, dynamic>>();
+    var map = value.checked<Map<dynamic, dynamic>>();
     if (_subMappers.isNotEmpty) {
       for (var m in _subMappers) {
         if (m.canDecode(map)) {

--- a/packages/dart_mappable/lib/src/mappers/default_mappers.dart
+++ b/packages/dart_mappable/lib/src/mappers/default_mappers.dart
@@ -39,6 +39,8 @@ class PrimitiveMapper<T extends Object> extends MapperBase<T>
 /// {@category Custom Mappers}
 abstract class EnumMapper<T extends Enum> extends SimpleMapper<T> {
   const EnumMapper();
+
+  Map<String, T> get enums;
 }
 
 /// A mapper that encodes a [DateTime] object into a serializable date format

--- a/packages/dart_mappable/lib/src/mappers/interface_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/interface_mapper.dart
@@ -15,6 +15,8 @@ enum FieldMode {
 
   /// A field that is both a constructor parameter and class member.
   field,
+
+  tuple,
 }
 
 /// A field defined in a class that is relevant for its mapping.
@@ -76,7 +78,7 @@ class Field<T extends Object, V> {
     }
   }
 
-  R decode<R>(Map<String, dynamic> value, DecodingContext context) {
+  R decode<R>(Map<dynamic, dynamic> value, DecodingContext context) {
     DecodingOptions? options;
     if (data != null) {
       options = DecodingOptions(data: data);
@@ -95,7 +97,7 @@ class Field<T extends Object, V> {
 class DecodingData<T extends Object> {
   DecodingData(this.value, this.context);
 
-  final Map<String, dynamic> value;
+  final Map<dynamic, dynamic> value;
   final DecodingContext context;
 
   V dec<V>(Field f) => f.decode(value, context);
@@ -147,7 +149,7 @@ abstract class InterfaceMapperBase<T extends Object> extends MapperBase<T> {
 
   @protected
   T decode(Object? value, DecodingContext context) {
-    var map = value.checked<Map<String, dynamic>>();
+    var map = value.checked<Map<dynamic, dynamic>>();
 
     var d = DecodingData<T>(map, context);
     if (context.args.isEmpty) {

--- a/packages/dart_mappable/lib/src/mappers/interface_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/interface_mapper.dart
@@ -184,7 +184,7 @@ abstract class InterfaceMapperBase<T extends Object> extends MapperBase<T> {
 
   @protected
   @pragma('vm:prefer-inline')
-  static Map<String, dynamic> encodeFields<T extends Object>(
+  static Map<dynamic, dynamic> encodeFields<T extends Object>(
     T value,
     Iterable<Field<T, dynamic>> fields,
     bool ignoreNull,
@@ -206,11 +206,11 @@ abstract class InterfaceMapperBase<T extends Object> extends MapperBase<T> {
     return {for (var f in fields) f.key: f.encode(value, context)};
   }
 
-  V decodeMap<V>(Map<String, dynamic> map) => decodeValue<V>(map);
+  V decodeMap<V>(Map<dynamic, dynamic> map) => decodeValue<V>(map);
 
-  Map<String, dynamic> encodeMap<V>(V object, [EncodingOptions? options]) {
+  Map<dynamic, dynamic> encodeMap<V>(V object, [EncodingOptions? options]) {
     var value = encodeValue<V>(object, options);
-    if (value is Map<String, dynamic>) {
+    if (value is Map<dynamic, dynamic>) {
       return value;
     } else {
       throw MapperException.incorrectEncoding(

--- a/packages/dart_mappable/pubspec.yaml
+++ b/packages/dart_mappable/pubspec.yaml
@@ -22,8 +22,8 @@ dependencies:
   type_plus: ^2.1.1
 
 dev_dependencies:
-  build_runner: ^2.4.14
+  build_runner: ^2.8.0
   dart_mappable_builder: ^4.6.1
-  lints: ^5.0.0
+  lints: ^6.0.0
   test: ^1.25.10
 

--- a/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
+++ b/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
@@ -151,7 +151,7 @@ class MappableBuilder implements Builder {
 
     for (var i = 0; i < discovered.length; i++) {
       for (var e in discovered[i].value) {
-        output.write('  p$i.${e.name3}Mapper.ensureInitialized();\n');
+        output.write('  p$i.${e.name}Mapper.ensureInitialized();\n');
       }
     }
 

--- a/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
+++ b/packages/dart_mappable_builder/lib/src/builders/mappable_builder.dart
@@ -151,7 +151,7 @@ class MappableBuilder implements Builder {
 
     for (var i = 0; i < discovered.length; i++) {
       for (var e in discovered[i].value) {
-        output.write('  p$i.${e.name}Mapper.ensureInitialized();\n');
+        output.write('  p$i.${e.name3}Mapper.ensureInitialized();\n');
       }
     }
 

--- a/packages/dart_mappable_builder/lib/src/elements/field/record_mapper_field_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/field/record_mapper_field_element.dart
@@ -61,7 +61,7 @@ class RecordMapperFieldElement extends MapperFieldElement {
   }();
 
   @override
-  final String mode = '';
+  String get mode => param.isNamed ? '' : ', mode: FieldMode.tuple';
 
   @override
   String get opt => '';

--- a/packages/dart_mappable_builder/lib/src/generators/enum_mapper_generator.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/enum_mapper_generator.dart
@@ -18,6 +18,11 @@ class EnumMapperGenerator extends MapperGenerator<TargetEnumMapperElement> {
             }
             return _instance!;
           }
+
+          @override
+          Map<String, ${element.prefixedClassName}> get enums => {
+            ${element.values.map((v) => "r'${v.name}': ${element.prefixedClassName}.${v.name},").join("\n      ")}
+          };
           
           static ${element.prefixedClassName} fromValue(dynamic value) {
             ensureInitialized();

--- a/packages/dart_mappable_builder/lib/src/generators/mixins/decoding_mixin.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/mixins/decoding_mixin.dart
@@ -161,7 +161,7 @@ mixin DecodingMixin on MapperGenerator<TargetClassMapperElement> {
 
     output.write(
       '\n'
-      '  static ${element.prefixedDecodingClassName}${element.typeParams} $fromMapName${element.typeParamsDeclaration}(Map<String, dynamic> map) {\n'
+      '  static ${element.prefixedDecodingClassName}${element.typeParams} $fromMapName${element.typeParamsDeclaration}(Map<dynamic, dynamic> map) {\n'
       '    return ensureInitialized().decodeMap<${element.prefixedDecodingClassName}${element.typeParams}>(map);\n'
       '  }\n'
       '  static ${element.prefixedDecodingClassName}${element.typeParams} $fromJsonName${element.typeParamsDeclaration}(String json) {\n'

--- a/packages/dart_mappable_builder/lib/src/generators/mixins/encoding_mixin.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/mixins/encoding_mixin.dart
@@ -14,7 +14,7 @@ mixin EncodingMixin on MapperGenerator<TargetClassMapperElement> {
     if (element.isAbstract) {
       output.write('''
         String $toJsonName();
-        Map<String, dynamic> $toMapName();
+        Map<dynamic, dynamic> $toMapName();
       ''');
       return;
     }
@@ -22,7 +22,7 @@ mixin EncodingMixin on MapperGenerator<TargetClassMapperElement> {
       String $toJsonName() {
         return ${element.mapperName}.ensureInitialized().encodeJson<${element.selfTypeParam}>(this as ${element.selfTypeParam});
       }
-      Map<String, dynamic> $toMapName() {
+      Map<dynamic, dynamic> $toMapName() {
         return ${element.mapperName}.ensureInitialized().encodeMap<${element.selfTypeParam}>(this as ${element.selfTypeParam});
       }
     ''');
@@ -36,7 +36,7 @@ mixin EncodingMixin on MapperGenerator<TargetClassMapperElement> {
       String $toJsonName() {
         return ${element.mapperName}.ensureInitialized().encodeJson<${element.selfTypeParam}>(this);
       }
-      Map<String, dynamic> $toMapName() {
+      Map<dynamic, dynamic> $toMapName() {
         return ${element.mapperName}.ensureInitialized().encodeMap<${element.selfTypeParam}>(this);
       }
     ''');

--- a/packages/dart_mappable_builder/lib/src/generators/record_mapper_generator.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/record_mapper_generator.dart
@@ -41,7 +41,7 @@ class RecordMapperGenerator extends MapperGenerator<RecordMapperElement> {
       output.write('''
       
       extension ${element.className}Mappable${element.typeParamsDeclaration} on ${element.className}${element.typeParams} {
-        Map<String, dynamic> toMap() {
+        Map<dynamic, dynamic> toMap() {
           return ${element.mapperName}.ensureInitialized().encodeMap(this);
         }
         
@@ -112,7 +112,7 @@ class RecordMapperGenerator extends MapperGenerator<RecordMapperElement> {
 
     output.write(
       '\n'
-      '  static ${element.className}${element.typeParams} $fromMapName${element.typeParamsDeclaration}(Map<String, dynamic> map) {\n'
+      '  static ${element.className}${element.typeParams} $fromMapName${element.typeParamsDeclaration}(Map<dynamic, dynamic> map) {\n'
       '    return ensureInitialized().decodeMap<${element.className}${element.typeParams}>(map);\n'
       '  }\n'
       '  static ${element.className}${element.typeParams} $fromJsonName${element.typeParamsDeclaration}(String json) {\n'

--- a/packages/dart_mappable_builder/pubspec.yaml
+++ b/packages/dart_mappable_builder/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   source_gen: ^4.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.14
+  build_runner: ^2.8.0
   build_test: ^3.3.0
-  lints: '>=1.0.0 <6.0.0'
+  lints: '^6.0.0'
   test: ^1.25.10
   

--- a/packages/dart_mappable_schema/analysis_options.yaml
+++ b/packages/dart_mappable_schema/analysis_options.yaml
@@ -1,0 +1,12 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+
+linter:
+  rules:
+    sort_pub_dependencies: true
+    prefer_relative_imports: true
+    prefer_single_quotes: true
+    depend_on_referenced_packages: true

--- a/packages/dart_mappable_schema/example/example.dart
+++ b/packages/dart_mappable_schema/example/example.dart
@@ -1,0 +1,19 @@
+import 'package:json_schema_builder/json_schema.dart';
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'example.mapper.dart';
+
+@MappableClass()
+class User with UserMappable {
+  final String name;
+  final int age;
+  final List<String> tags;
+  User({required this.name, this.age = 10, required this.tags});
+}
+
+void main() {
+  UserMapper.ensureInitialized();
+
+  final schema = buildJsonSchemaFor<User>();
+  print(schema.toMap());
+}

--- a/packages/dart_mappable_schema/example/example.dart
+++ b/packages/dart_mappable_schema/example/example.dart
@@ -16,7 +16,7 @@ class User with UserMappable {
     required this.name,
     this.age = 10,
     required this.tags,
-    required this.type,
+    this.type = UserType.admin,
   });
 }
 

--- a/packages/dart_mappable_schema/example/example.dart
+++ b/packages/dart_mappable_schema/example/example.dart
@@ -12,11 +12,13 @@ class User with UserMappable {
   final int age;
   final List<String> tags;
   final UserType type;
+  final (int, int, String) info;
   User({
     required this.name,
     this.age = 10,
     required this.tags,
     this.type = UserType.admin,
+    required this.info
   });
 }
 

--- a/packages/dart_mappable_schema/example/example.dart
+++ b/packages/dart_mappable_schema/example/example.dart
@@ -1,19 +1,28 @@
-import 'package:json_schema_builder/json_schema.dart';
+import 'package:dart_mappable_schema/json_schema.dart';
 import 'package:dart_mappable/dart_mappable.dart';
 
 part 'example.mapper.dart';
+
+@MappableEnum()
+enum UserType { user, admin }
 
 @MappableClass()
 class User with UserMappable {
   final String name;
   final int age;
   final List<String> tags;
-  User({required this.name, this.age = 10, required this.tags});
+  final UserType type;
+  User({
+    required this.name,
+    this.age = 10,
+    required this.tags,
+    required this.type,
+  });
 }
 
 void main() {
   UserMapper.ensureInitialized();
 
   final schema = buildJsonSchemaFor<User>();
-  print(schema.toMap());
+  print(schema.toJson());
 }

--- a/packages/dart_mappable_schema/example/example.mapper.dart
+++ b/packages/dart_mappable_schema/example/example.mapper.dart
@@ -1,0 +1,134 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'example.dart';
+
+class UserMapper extends ClassMapperBase<User> {
+  UserMapper._();
+
+  static UserMapper? _instance;
+  static UserMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = UserMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'User';
+
+  static String _$name(User v) => v.name;
+  static const Field<User, String> _f$name = Field('name', _$name);
+  static int _$age(User v) => v.age;
+  static const Field<User, int> _f$age = Field(
+    'age',
+    _$age,
+    opt: true,
+    def: 10,
+  );
+  static List<String> _$tags(User v) => v.tags;
+  static const Field<User, List<String>> _f$tags = Field('tags', _$tags);
+
+  @override
+  final MappableFields<User> fields = const {
+    #name: _f$name,
+    #age: _f$age,
+    #tags: _f$tags,
+  };
+
+  static User _instantiate(DecodingData data) {
+    return User(
+      name: data.dec(_f$name),
+      age: data.dec(_f$age),
+      tags: data.dec(_f$tags),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static User fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<User>(map);
+  }
+
+  static User fromJson(String json) {
+    return ensureInitialized().decodeJson<User>(json);
+  }
+}
+
+mixin UserMappable {
+  String toJson() {
+    return UserMapper.ensureInitialized().encodeJson<User>(this as User);
+  }
+
+  Map<String, dynamic> toMap() {
+    return UserMapper.ensureInitialized().encodeMap<User>(this as User);
+  }
+
+  UserCopyWith<User, User, User> get copyWith =>
+      _UserCopyWithImpl<User, User>(this as User, $identity, $identity);
+  @override
+  String toString() {
+    return UserMapper.ensureInitialized().stringifyValue(this as User);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return UserMapper.ensureInitialized().equalsValue(this as User, other);
+  }
+
+  @override
+  int get hashCode {
+    return UserMapper.ensureInitialized().hashValue(this as User);
+  }
+}
+
+extension UserValueCopy<$R, $Out> on ObjectCopyWith<$R, User, $Out> {
+  UserCopyWith<$R, User, $Out> get $asUser =>
+      $base.as((v, t, t2) => _UserCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class UserCopyWith<$R, $In extends User, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>> get tags;
+  $R call({String? name, int? age, List<String>? tags});
+  UserCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _UserCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, User, $Out>
+    implements UserCopyWith<$R, User, $Out> {
+  _UserCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<User> $mapper = UserMapper.ensureInitialized();
+  @override
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>> get tags =>
+      ListCopyWith(
+        $value.tags,
+        (v, t) => ObjectCopyWith(v, $identity, t),
+        (v) => call(tags: v),
+      );
+  @override
+  $R call({String? name, int? age, List<String>? tags}) => $apply(
+    FieldCopyWithData({
+      if (name != null) #name: name,
+      if (age != null) #age: age,
+      if (tags != null) #tags: tags,
+    }),
+  );
+  @override
+  User $make(CopyWithData data) => User(
+    name: data.get(#name, or: $value.name),
+    age: data.get(#age, or: $value.age),
+    tags: data.get(#tags, or: $value.tags),
+  );
+
+  @override
+  UserCopyWith<$R2, User, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _UserCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/packages/dart_mappable_schema/example/example.mapper.dart
+++ b/packages/dart_mappable_schema/example/example.mapper.dart
@@ -121,7 +121,7 @@ class UserMapper extends ClassMapperBase<User> {
   @override
   final Function instantiate = _instantiate;
 
-  static User fromMap(Map<String, dynamic> map) {
+  static User fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<User>(map);
   }
 
@@ -135,7 +135,7 @@ mixin UserMappable {
     return UserMapper.ensureInitialized().encodeJson<User>(this as User);
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return UserMapper.ensureInitialized().encodeMap<User>(this as User);
   }
 
@@ -275,7 +275,7 @@ class _t$_R0Mapper extends RecordMapperBase<_t$_R0> {
   @override
   final Function instantiate = _instantiate;
 
-  static _t$_R0<A, B, C> fromMap<A, B, C>(Map<String, dynamic> map) {
+  static _t$_R0<A, B, C> fromMap<A, B, C>(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<_t$_R0<A, B, C>>(map);
   }
 

--- a/packages/dart_mappable_schema/example/example.mapper.dart
+++ b/packages/dart_mappable_schema/example/example.mapper.dart
@@ -67,6 +67,7 @@ class UserMapper extends ClassMapperBase<User> {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = UserMapper._());
       UserTypeMapper.ensureInitialized();
+      _t$_R0Mapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -92,6 +93,11 @@ class UserMapper extends ClassMapperBase<User> {
     opt: true,
     def: UserType.admin,
   );
+  static _t$_R0<int, int, String> _$info(User v) => v.info;
+  static const Field<User, _t$_R0<int, int, String>> _f$info = Field(
+    'info',
+    _$info,
+  );
 
   @override
   final MappableFields<User> fields = const {
@@ -99,6 +105,7 @@ class UserMapper extends ClassMapperBase<User> {
     #age: _f$age,
     #tags: _f$tags,
     #type: _f$type,
+    #info: _f$info,
   };
 
   static User _instantiate(DecodingData data) {
@@ -107,6 +114,7 @@ class UserMapper extends ClassMapperBase<User> {
       age: data.dec(_f$age),
       tags: data.dec(_f$tags),
       type: data.dec(_f$type),
+      info: data.dec(_f$info),
     );
   }
 
@@ -157,7 +165,13 @@ extension UserValueCopy<$R, $Out> on ObjectCopyWith<$R, User, $Out> {
 abstract class UserCopyWith<$R, $In extends User, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>> get tags;
-  $R call({String? name, int? age, List<String>? tags, UserType? type});
+  $R call({
+    String? name,
+    int? age,
+    List<String>? tags,
+    UserType? type,
+    _t$_R0<int, int, String>? info,
+  });
   UserCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -175,25 +189,98 @@ class _UserCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, User, $Out>
         (v) => call(tags: v),
       );
   @override
-  $R call({String? name, int? age, List<String>? tags, UserType? type}) =>
-      $apply(
-        FieldCopyWithData({
-          if (name != null) #name: name,
-          if (age != null) #age: age,
-          if (tags != null) #tags: tags,
-          if (type != null) #type: type,
-        }),
-      );
+  $R call({
+    String? name,
+    int? age,
+    List<String>? tags,
+    UserType? type,
+    _t$_R0<int, int, String>? info,
+  }) => $apply(
+    FieldCopyWithData({
+      if (name != null) #name: name,
+      if (age != null) #age: age,
+      if (tags != null) #tags: tags,
+      if (type != null) #type: type,
+      if (info != null) #info: info,
+    }),
+  );
   @override
   User $make(CopyWithData data) => User(
     name: data.get(#name, or: $value.name),
     age: data.get(#age, or: $value.age),
     tags: data.get(#tags, or: $value.tags),
     type: data.get(#type, or: $value.type),
+    info: data.get(#info, or: $value.info),
   );
 
   @override
   UserCopyWith<$R2, User, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
       _UserCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+typedef _t$_R0<A, B, C> = (A, B, C);
+
+class _t$_R0Mapper extends RecordMapperBase<_t$_R0> {
+  static _t$_R0Mapper? _instance;
+  _t$_R0Mapper._();
+
+  static _t$_R0Mapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = _t$_R0Mapper._());
+      MapperBase.addType(<A, B, C>(f) => f<(A, B, C)>());
+    }
+    return _instance!;
+  }
+
+  static dynamic _$$1(_t$_R0 v) => v.$1;
+  static dynamic _arg$$1<A, B, C>(f) => f<A>();
+  static const Field<_t$_R0, dynamic> _f$$1 = Field(
+    '\$1',
+    _$$1,
+    mode: FieldMode.tuple,
+    arg: _arg$$1,
+  );
+  static dynamic _$$2(_t$_R0 v) => v.$2;
+  static dynamic _arg$$2<A, B, C>(f) => f<B>();
+  static const Field<_t$_R0, dynamic> _f$$2 = Field(
+    '\$2',
+    _$$2,
+    mode: FieldMode.tuple,
+    arg: _arg$$2,
+  );
+  static dynamic _$$3(_t$_R0 v) => v.$3;
+  static dynamic _arg$$3<A, B, C>(f) => f<C>();
+  static const Field<_t$_R0, dynamic> _f$$3 = Field(
+    '\$3',
+    _$$3,
+    mode: FieldMode.tuple,
+    arg: _arg$$3,
+  );
+
+  @override
+  final MappableFields<_t$_R0> fields = const {
+    #$1: _f$$1,
+    #$2: _f$$2,
+    #$3: _f$$3,
+  };
+
+  @override
+  Function get typeFactory =>
+      <A, B, C>(f) => f<_t$_R0<A, B, C>>();
+
+  static _t$_R0<A, B, C> _instantiate<A, B, C>(DecodingData<_t$_R0> data) {
+    return (data.dec(_f$$1), data.dec(_f$$2), data.dec(_f$$3));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static _t$_R0<A, B, C> fromMap<A, B, C>(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<_t$_R0<A, B, C>>(map);
+  }
+
+  static _t$_R0<A, B, C> fromJson<A, B, C>(String json) {
+    return ensureInitialized().decodeJson<_t$_R0<A, B, C>>(json);
+  }
 }
 

--- a/packages/dart_mappable_schema/example/example.mapper.dart
+++ b/packages/dart_mappable_schema/example/example.mapper.dart
@@ -7,6 +7,58 @@
 
 part of 'example.dart';
 
+class UserTypeMapper extends EnumMapper<UserType> {
+  UserTypeMapper._();
+
+  static UserTypeMapper? _instance;
+  static UserTypeMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = UserTypeMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  Map<String, UserType> get enums => {
+    r'user': UserType.user,
+    r'admin': UserType.admin,
+  };
+
+  static UserType fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  UserType decode(dynamic value) {
+    switch (value) {
+      case r'user':
+        return UserType.user;
+      case r'admin':
+        return UserType.admin;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(UserType self) {
+    switch (self) {
+      case UserType.user:
+        return r'user';
+      case UserType.admin:
+        return r'admin';
+    }
+  }
+}
+
+extension UserTypeMapperExtension on UserType {
+  String toValue() {
+    UserTypeMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<UserType>(this) as String;
+  }
+}
+
 class UserMapper extends ClassMapperBase<User> {
   UserMapper._();
 
@@ -14,6 +66,7 @@ class UserMapper extends ClassMapperBase<User> {
   static UserMapper ensureInitialized() {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = UserMapper._());
+      UserTypeMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -32,12 +85,15 @@ class UserMapper extends ClassMapperBase<User> {
   );
   static List<String> _$tags(User v) => v.tags;
   static const Field<User, List<String>> _f$tags = Field('tags', _$tags);
+  static UserType _$type(User v) => v.type;
+  static const Field<User, UserType> _f$type = Field('type', _$type);
 
   @override
   final MappableFields<User> fields = const {
     #name: _f$name,
     #age: _f$age,
     #tags: _f$tags,
+    #type: _f$type,
   };
 
   static User _instantiate(DecodingData data) {
@@ -45,6 +101,7 @@ class UserMapper extends ClassMapperBase<User> {
       name: data.dec(_f$name),
       age: data.dec(_f$age),
       tags: data.dec(_f$tags),
+      type: data.dec(_f$type),
     );
   }
 
@@ -95,7 +152,7 @@ extension UserValueCopy<$R, $Out> on ObjectCopyWith<$R, User, $Out> {
 abstract class UserCopyWith<$R, $In extends User, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>> get tags;
-  $R call({String? name, int? age, List<String>? tags});
+  $R call({String? name, int? age, List<String>? tags, UserType? type});
   UserCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -113,18 +170,21 @@ class _UserCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, User, $Out>
         (v) => call(tags: v),
       );
   @override
-  $R call({String? name, int? age, List<String>? tags}) => $apply(
-    FieldCopyWithData({
-      if (name != null) #name: name,
-      if (age != null) #age: age,
-      if (tags != null) #tags: tags,
-    }),
-  );
+  $R call({String? name, int? age, List<String>? tags, UserType? type}) =>
+      $apply(
+        FieldCopyWithData({
+          if (name != null) #name: name,
+          if (age != null) #age: age,
+          if (tags != null) #tags: tags,
+          if (type != null) #type: type,
+        }),
+      );
   @override
   User $make(CopyWithData data) => User(
     name: data.get(#name, or: $value.name),
     age: data.get(#age, or: $value.age),
     tags: data.get(#tags, or: $value.tags),
+    type: data.get(#type, or: $value.type),
   );
 
   @override

--- a/packages/dart_mappable_schema/example/example.mapper.dart
+++ b/packages/dart_mappable_schema/example/example.mapper.dart
@@ -86,7 +86,12 @@ class UserMapper extends ClassMapperBase<User> {
   static List<String> _$tags(User v) => v.tags;
   static const Field<User, List<String>> _f$tags = Field('tags', _$tags);
   static UserType _$type(User v) => v.type;
-  static const Field<User, UserType> _f$type = Field('type', _$type);
+  static const Field<User, UserType> _f$type = Field(
+    'type',
+    _$type,
+    opt: true,
+    def: UserType.admin,
+  );
 
   @override
   final MappableFields<User> fields = const {

--- a/packages/dart_mappable_schema/example/polymorphism_example.dart
+++ b/packages/dart_mappable_schema/example/polymorphism_example.dart
@@ -1,6 +1,5 @@
 import 'package:dart_mappable/dart_mappable.dart';
-
-import 'package:json_schema_builder/json_schema.dart';
+import 'package:dart_mappable_schema/json_schema.dart';
 
 part 'polymorphism_example.mapper.dart';
 
@@ -24,6 +23,6 @@ final class Dog extends Animal with DogMappable {
 void main() {
   AnimalMapper.ensureInitialized();
 
-  final schema = buildJsonSchemaFor<Animal>();
+  final schema = AnimalMapper.ensureInitialized().toJsonSchema();
   print(schema.toJson());
 }

--- a/packages/dart_mappable_schema/example/polymorphism_example.dart
+++ b/packages/dart_mappable_schema/example/polymorphism_example.dart
@@ -1,0 +1,29 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+import 'package:json_schema_builder/json_schema.dart';
+
+part 'polymorphism_example.mapper.dart';
+
+@MappableClass(discriminatorKey: 'kind')
+sealed class Animal with AnimalMappable {}
+
+@MappableClass(discriminatorValue: 'cat')
+final class Cat extends Animal with CatMappable {
+  Cat(this.name, this.lives);
+  final String name;
+  final int lives;
+}
+
+@MappableClass(discriminatorValue: 'dog')
+final class Dog extends Animal with DogMappable {
+  Dog(this.name, this.barkVolume);
+  final String name;
+  final int barkVolume;
+}
+
+void main() {
+  AnimalMapper.ensureInitialized();
+
+  final schema = buildJsonSchemaFor<Animal>();
+  print(schema.toJson());
+}

--- a/packages/dart_mappable_schema/example/polymorphism_example.mapper.dart
+++ b/packages/dart_mappable_schema/example/polymorphism_example.mapper.dart
@@ -1,0 +1,282 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'polymorphism_example.dart';
+
+class AnimalMapper extends ClassMapperBase<Animal> {
+  AnimalMapper._();
+
+  static AnimalMapper? _instance;
+  static AnimalMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = AnimalMapper._());
+      CatMapper.ensureInitialized();
+      DogMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'Animal';
+
+  @override
+  final MappableFields<Animal> fields = const {};
+
+  static Animal _instantiate(DecodingData data) {
+    throw MapperException.missingSubclass(
+      'Animal',
+      'kind',
+      '${data.value['kind']}',
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static Animal fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<Animal>(map);
+  }
+
+  static Animal fromJson(String json) {
+    return ensureInitialized().decodeJson<Animal>(json);
+  }
+}
+
+mixin AnimalMappable {
+  String toJson();
+  Map<String, dynamic> toMap();
+  AnimalCopyWith<Animal, Animal, Animal> get copyWith;
+}
+
+abstract class AnimalCopyWith<$R, $In extends Animal, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call();
+  AnimalCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class CatMapper extends SubClassMapperBase<Cat> {
+  CatMapper._();
+
+  static CatMapper? _instance;
+  static CatMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = CatMapper._());
+      AnimalMapper.ensureInitialized().addSubMapper(_instance!);
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'Cat';
+
+  static String _$name(Cat v) => v.name;
+  static const Field<Cat, String> _f$name = Field('name', _$name);
+  static int _$lives(Cat v) => v.lives;
+  static const Field<Cat, int> _f$lives = Field('lives', _$lives);
+
+  @override
+  final MappableFields<Cat> fields = const {#name: _f$name, #lives: _f$lives};
+
+  @override
+  final String discriminatorKey = 'kind';
+  @override
+  final dynamic discriminatorValue = 'cat';
+  @override
+  late final ClassMapperBase superMapper = AnimalMapper.ensureInitialized();
+
+  static Cat _instantiate(DecodingData data) {
+    return Cat(data.dec(_f$name), data.dec(_f$lives));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static Cat fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<Cat>(map);
+  }
+
+  static Cat fromJson(String json) {
+    return ensureInitialized().decodeJson<Cat>(json);
+  }
+}
+
+mixin CatMappable {
+  String toJson() {
+    return CatMapper.ensureInitialized().encodeJson<Cat>(this as Cat);
+  }
+
+  Map<String, dynamic> toMap() {
+    return CatMapper.ensureInitialized().encodeMap<Cat>(this as Cat);
+  }
+
+  CatCopyWith<Cat, Cat, Cat> get copyWith =>
+      _CatCopyWithImpl<Cat, Cat>(this as Cat, $identity, $identity);
+  @override
+  String toString() {
+    return CatMapper.ensureInitialized().stringifyValue(this as Cat);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return CatMapper.ensureInitialized().equalsValue(this as Cat, other);
+  }
+
+  @override
+  int get hashCode {
+    return CatMapper.ensureInitialized().hashValue(this as Cat);
+  }
+}
+
+extension CatValueCopy<$R, $Out> on ObjectCopyWith<$R, Cat, $Out> {
+  CatCopyWith<$R, Cat, $Out> get $asCat =>
+      $base.as((v, t, t2) => _CatCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class CatCopyWith<$R, $In extends Cat, $Out>
+    implements AnimalCopyWith<$R, $In, $Out> {
+  @override
+  $R call({String? name, int? lives});
+  CatCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _CatCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Cat, $Out>
+    implements CatCopyWith<$R, Cat, $Out> {
+  _CatCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<Cat> $mapper = CatMapper.ensureInitialized();
+  @override
+  $R call({String? name, int? lives}) => $apply(
+    FieldCopyWithData({
+      if (name != null) #name: name,
+      if (lives != null) #lives: lives,
+    }),
+  );
+  @override
+  Cat $make(CopyWithData data) =>
+      Cat(data.get(#name, or: $value.name), data.get(#lives, or: $value.lives));
+
+  @override
+  CatCopyWith<$R2, Cat, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _CatCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class DogMapper extends SubClassMapperBase<Dog> {
+  DogMapper._();
+
+  static DogMapper? _instance;
+  static DogMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = DogMapper._());
+      AnimalMapper.ensureInitialized().addSubMapper(_instance!);
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'Dog';
+
+  static String _$name(Dog v) => v.name;
+  static const Field<Dog, String> _f$name = Field('name', _$name);
+  static int _$barkVolume(Dog v) => v.barkVolume;
+  static const Field<Dog, int> _f$barkVolume = Field(
+    'barkVolume',
+    _$barkVolume,
+  );
+
+  @override
+  final MappableFields<Dog> fields = const {
+    #name: _f$name,
+    #barkVolume: _f$barkVolume,
+  };
+
+  @override
+  final String discriminatorKey = 'kind';
+  @override
+  final dynamic discriminatorValue = 'dog';
+  @override
+  late final ClassMapperBase superMapper = AnimalMapper.ensureInitialized();
+
+  static Dog _instantiate(DecodingData data) {
+    return Dog(data.dec(_f$name), data.dec(_f$barkVolume));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static Dog fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<Dog>(map);
+  }
+
+  static Dog fromJson(String json) {
+    return ensureInitialized().decodeJson<Dog>(json);
+  }
+}
+
+mixin DogMappable {
+  String toJson() {
+    return DogMapper.ensureInitialized().encodeJson<Dog>(this as Dog);
+  }
+
+  Map<String, dynamic> toMap() {
+    return DogMapper.ensureInitialized().encodeMap<Dog>(this as Dog);
+  }
+
+  DogCopyWith<Dog, Dog, Dog> get copyWith =>
+      _DogCopyWithImpl<Dog, Dog>(this as Dog, $identity, $identity);
+  @override
+  String toString() {
+    return DogMapper.ensureInitialized().stringifyValue(this as Dog);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return DogMapper.ensureInitialized().equalsValue(this as Dog, other);
+  }
+
+  @override
+  int get hashCode {
+    return DogMapper.ensureInitialized().hashValue(this as Dog);
+  }
+}
+
+extension DogValueCopy<$R, $Out> on ObjectCopyWith<$R, Dog, $Out> {
+  DogCopyWith<$R, Dog, $Out> get $asDog =>
+      $base.as((v, t, t2) => _DogCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class DogCopyWith<$R, $In extends Dog, $Out>
+    implements AnimalCopyWith<$R, $In, $Out> {
+  @override
+  $R call({String? name, int? barkVolume});
+  DogCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _DogCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Dog, $Out>
+    implements DogCopyWith<$R, Dog, $Out> {
+  _DogCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<Dog> $mapper = DogMapper.ensureInitialized();
+  @override
+  $R call({String? name, int? barkVolume}) => $apply(
+    FieldCopyWithData({
+      if (name != null) #name: name,
+      if (barkVolume != null) #barkVolume: barkVolume,
+    }),
+  );
+  @override
+  Dog $make(CopyWithData data) => Dog(
+    data.get(#name, or: $value.name),
+    data.get(#barkVolume, or: $value.barkVolume),
+  );
+
+  @override
+  DogCopyWith<$R2, Dog, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _DogCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/packages/dart_mappable_schema/example/polymorphism_example.mapper.dart
+++ b/packages/dart_mappable_schema/example/polymorphism_example.mapper.dart
@@ -37,7 +37,7 @@ class AnimalMapper extends ClassMapperBase<Animal> {
   @override
   final Function instantiate = _instantiate;
 
-  static Animal fromMap(Map<String, dynamic> map) {
+  static Animal fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<Animal>(map);
   }
 
@@ -48,7 +48,7 @@ class AnimalMapper extends ClassMapperBase<Animal> {
 
 mixin AnimalMappable {
   String toJson();
-  Map<String, dynamic> toMap();
+  Map<dynamic, dynamic> toMap();
   AnimalCopyWith<Animal, Animal, Animal> get copyWith;
 }
 
@@ -95,7 +95,7 @@ class CatMapper extends SubClassMapperBase<Cat> {
   @override
   final Function instantiate = _instantiate;
 
-  static Cat fromMap(Map<String, dynamic> map) {
+  static Cat fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<Cat>(map);
   }
 
@@ -109,7 +109,7 @@ mixin CatMappable {
     return CatMapper.ensureInitialized().encodeJson<Cat>(this as Cat);
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return CatMapper.ensureInitialized().encodeMap<Cat>(this as Cat);
   }
 
@@ -208,7 +208,7 @@ class DogMapper extends SubClassMapperBase<Dog> {
   @override
   final Function instantiate = _instantiate;
 
-  static Dog fromMap(Map<String, dynamic> map) {
+  static Dog fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<Dog>(map);
   }
 
@@ -222,7 +222,7 @@ mixin DogMappable {
     return DogMapper.ensureInitialized().encodeJson<Dog>(this as Dog);
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return DogMapper.ensureInitialized().encodeMap<Dog>(this as Dog);
   }
 

--- a/packages/dart_mappable_schema/lib/json_schema.dart
+++ b/packages/dart_mappable_schema/lib/json_schema.dart
@@ -1,0 +1,12 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+import 'json_schema.dart';
+
+export 'src/json_schema.dart';
+export 'src/mapper_to_schema.dart';
+
+extension MapperToSchema<T extends Object> on ClassMapperBase<T> {
+  JsonSchema toJsonSchema() {
+    return buildJsonSchemaFor<T>();
+  }
+}

--- a/packages/dart_mappable_schema/lib/src/json_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.dart
@@ -1,0 +1,407 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+import 'json_schema_hook.dart';
+
+part 'json_schema.mapper.dart';
+
+@MappableClass(ignoreNull: true)
+final class JsonSchema with JsonSchemaMappable {
+  @MappableField(key: r'$id')
+  final String? id;
+
+  @MappableField(key: r'$schema')
+  final String? schema;
+
+  @MappableField(key: r'$ref')
+  final String? ref;
+
+  final String? title;
+  final String? description;
+
+  final JsonSchemaType? type;
+  final List<Object?>? enumValues;
+
+  final JsonSchemaItems? items;
+  final Map<String, JsonSchema>? properties;
+  final List<String>? required;
+  final JsonSchemaAdditionalProperties? additionalProperties;
+  final Map<String, JsonSchema>? patternProperties;
+
+  // draft-07: definitions
+  final Map<String, JsonSchema>? definitions;
+
+  // draft-07: allOf, anyOf, oneOf, not
+  final List<JsonSchema>? allOf;
+  final List<JsonSchema>? anyOf;
+  final List<JsonSchema>? oneOf;
+
+  final JsonSchema? not;
+
+  // draft-07: if, then, else
+  final JsonSchema? ifSchema;
+  final JsonSchema? thenSchema;
+  final JsonSchema? elseSchema;
+
+  // draft-07: numeric
+  final num? multipleOf;
+  final num? maximum;
+  final bool? exclusiveMaximum;
+  final num? minimum;
+  final bool? exclusiveMinimum;
+
+  // draft-07: string
+  final int? maxLength;
+  final int? minLength;
+  final String? pattern;
+  final String? format;
+
+  // draft-07: array
+  final int? maxItems;
+  final int? minItems;
+  final bool? uniqueItems;
+  final List<Object?>? contains;
+
+  // draft-07: object
+  final int? maxProperties;
+  final int? minProperties;
+  final List<String>? dependencies;
+
+  @MappableField(key: 'default')
+  final Object? defaultValue;
+
+  JsonSchema({
+    this.id,
+    this.schema,
+    this.ref,
+    this.title,
+    this.description,
+    this.type,
+    this.enumValues,
+    this.items,
+    this.properties,
+    this.required,
+    this.additionalProperties,
+    this.patternProperties,
+    this.definitions,
+    this.allOf,
+    this.anyOf,
+    this.oneOf,
+    this.not,
+    this.ifSchema,
+    this.thenSchema,
+    this.elseSchema,
+    this.multipleOf,
+    this.maximum,
+    this.exclusiveMaximum,
+    this.minimum,
+    this.exclusiveMinimum,
+    this.maxLength,
+    this.minLength,
+    this.pattern,
+    this.format,
+    this.maxItems,
+    this.minItems,
+    this.uniqueItems,
+    this.contains,
+    this.maxProperties,
+    this.minProperties,
+    this.dependencies,
+    this.defaultValue,
+  });
+
+  factory JsonSchema.allOf(
+    List<JsonSchema> schemas, {
+    String? description,
+    String? title,
+  }) => JsonSchema(title: title, description: description, allOf: schemas);
+
+  factory JsonSchema.anyOf(
+    List<JsonSchema> schemas, {
+    String? description,
+    String? title,
+  }) => JsonSchema(title: title, description: description, anyOf: schemas);
+
+  factory JsonSchema.array(
+    JsonSchema itemSchema, {
+    String? description,
+    String? title,
+    int? minItems,
+    int? maxItems,
+    bool? uniqueItems,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    type: JsonSchemaTypeSingle('array'),
+    items: JsonSchemaItemsSingle(itemSchema),
+    minItems: minItems,
+    maxItems: maxItems,
+    uniqueItems: uniqueItems,
+  );
+
+  factory JsonSchema.boolean({
+    String? description,
+    String? title,
+    Object? defaultValue,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    type: JsonSchemaTypeSingle('boolean'),
+    defaultValue: defaultValue,
+  );
+
+  factory JsonSchema.conditional({
+    JsonSchema? ifSchema,
+    JsonSchema? thenSchema,
+    JsonSchema? elseSchema,
+    String? description,
+    String? title,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    ifSchema: ifSchema,
+    thenSchema: thenSchema,
+    elseSchema: elseSchema,
+  );
+
+  factory JsonSchema.enumeration(
+    List<Object?> values, {
+    String? description,
+    String? title,
+    Object? defaultValue,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    enumValues: values,
+    defaultValue: defaultValue,
+  );
+
+  factory JsonSchema.integer({
+    String? description,
+    String? title,
+    num? minimum,
+    num? maximum,
+    bool? exclusiveMinimum,
+    bool? exclusiveMaximum,
+    num? multipleOf,
+    Object? defaultValue,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    type: JsonSchemaTypeSingle('integer'),
+    minimum: minimum,
+    maximum: maximum,
+    exclusiveMinimum: exclusiveMinimum,
+    exclusiveMaximum: exclusiveMaximum,
+    multipleOf: multipleOf,
+    defaultValue: defaultValue,
+  );
+
+  factory JsonSchema.not(
+    JsonSchema schema, {
+    String? description,
+    String? title,
+  }) => JsonSchema(title: title, description: description, not: schema);
+
+  factory JsonSchema.nullType({
+    String? description,
+    String? title,
+    Object? defaultValue,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    type: JsonSchemaTypeSingle('null'),
+    defaultValue: defaultValue,
+  );
+
+  factory JsonSchema.number({
+    String? description,
+    String? title,
+    num? minimum,
+    num? maximum,
+    bool? exclusiveMinimum,
+    bool? exclusiveMaximum,
+    num? multipleOf,
+    Object? defaultValue,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    type: JsonSchemaTypeSingle('number'),
+    minimum: minimum,
+    maximum: maximum,
+    exclusiveMinimum: exclusiveMinimum,
+    exclusiveMaximum: exclusiveMaximum,
+    multipleOf: multipleOf,
+    defaultValue: defaultValue,
+  );
+
+  factory JsonSchema.object(
+    Map<String, JsonSchema> properties, {
+    String? schema,
+    String? id,
+    String? description,
+    String? title,
+    List<String>? required,
+    JsonSchemaAdditionalProperties? additionalProperties,
+    Map<String, JsonSchema>? patternProperties,
+    int? minProperties,
+    int? maxProperties,
+    Map<String, JsonSchema>? definitions,
+  }) => JsonSchema(
+    schema: schema,
+    id: id,
+    title: title,
+    description: description,
+    type: JsonSchemaTypeSingle('object'),
+    properties: properties,
+    required: required,
+    additionalProperties: additionalProperties,
+    patternProperties: patternProperties,
+    minProperties: minProperties,
+    maxProperties: maxProperties,
+    definitions: definitions,
+  );
+
+  factory JsonSchema.oneOf(
+    List<JsonSchema> schemas, {
+    String? description,
+    String? title,
+  }) => JsonSchema(title: title, description: description, oneOf: schemas);
+
+  factory JsonSchema.refSchema(
+    String ref, {
+    String? title,
+    String? description,
+  }) => JsonSchema(ref: ref, title: title, description: description);
+
+  factory JsonSchema.string({
+    String? description,
+    String? title,
+    int? minLength,
+    int? maxLength,
+    String? pattern,
+    String? format,
+    Object? defaultValue,
+    List<Object?>? enumValues,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    type: JsonSchemaTypeSingle('string'),
+    minLength: minLength,
+    maxLength: maxLength,
+    pattern: pattern,
+    format: format,
+    defaultValue: defaultValue,
+    enumValues: enumValues,
+  );
+
+  factory JsonSchema.tuple(
+    List<JsonSchema> itemSchemas, {
+    String? description,
+    String? title,
+    int? minItems,
+    int? maxItems,
+    bool? uniqueItems,
+  }) => JsonSchema(
+    title: title,
+    description: description,
+    type: JsonSchemaTypeSingle('array'),
+    items: JsonSchemaItemsArray(itemSchemas),
+    minItems: minItems,
+    maxItems: maxItems,
+    uniqueItems: uniqueItems,
+  );
+
+  static JsonSchema fromJson(String json) => JsonSchemaMapper.fromJson(json);
+
+  static JsonSchema fromMap(Map<String, dynamic> map) =>
+      JsonSchemaMapper.fromMap(map);
+}
+
+// additionalProperties: bool | schema
+@MappableClass(hook: JsonSchemaAdditionalPropertiesHook())
+sealed class JsonSchemaAdditionalProperties
+    with JsonSchemaAdditionalPropertiesMappable {}
+
+@MappableClass(
+  discriminatorValue: JsonSchemaAdditionalPropertiesForBool.checkType,
+)
+final class JsonSchemaAdditionalPropertiesForBool
+    extends JsonSchemaAdditionalProperties
+    with JsonSchemaAdditionalPropertiesForBoolMappable {
+  final bool value;
+  JsonSchemaAdditionalPropertiesForBool(this.value);
+
+  static bool checkType(dynamic value) {
+    return value is bool;
+  }
+}
+
+@MappableClass(
+  discriminatorValue: JsonSchemaAdditionalPropertiesForSchema.checkType,
+)
+final class JsonSchemaAdditionalPropertiesForSchema
+    extends JsonSchemaAdditionalProperties
+    with JsonSchemaAdditionalPropertiesForSchemaMappable {
+  final JsonSchema schema;
+  JsonSchemaAdditionalPropertiesForSchema(this.schema);
+
+  static bool checkType(dynamic value) {
+    return value is Map<String, dynamic>;
+  }
+}
+
+// items: schema | [schema]
+@MappableClass(hook: JsonSchemaItemsHook())
+sealed class JsonSchemaItems with JsonSchemaItemsMappable {}
+
+@MappableClass(discriminatorValue: JsonSchemaItemsArray.checkType)
+final class JsonSchemaItemsArray extends JsonSchemaItems
+    with JsonSchemaItemsArrayMappable {
+  final List<JsonSchema> schemas;
+  JsonSchemaItemsArray(this.schemas);
+
+  static bool checkType(dynamic value) {
+    // tuple form encoded as an array of schemas
+    return value is List;
+  }
+}
+
+@MappableClass(discriminatorValue: JsonSchemaItemsSingle.checkType)
+final class JsonSchemaItemsSingle extends JsonSchemaItems
+    with JsonSchemaItemsSingleMappable {
+  final JsonSchema schema;
+  JsonSchemaItemsSingle(this.schema);
+
+  static bool checkType(dynamic value) {
+    // single item schema encoded as an object
+    return value is Map<String, dynamic>;
+  }
+}
+
+// type: string | [string]
+@MappableClass(hook: JsonSchemaTypeHook())
+sealed class JsonSchemaType with JsonSchemaTypeMappable {}
+
+@MappableClass(discriminatorValue: JsonSchemaTypeArray.checkType)
+final class JsonSchemaTypeArray extends JsonSchemaType
+    with JsonSchemaTypeArrayMappable {
+  final List<String> values;
+  JsonSchemaTypeArray(this.values);
+
+  static bool checkType(dynamic value) {
+    // list of primitive strings: ["string", "null", ...]
+    return value is List;
+  }
+}
+
+@MappableClass(discriminatorValue: JsonSchemaTypeSingle.checkType)
+final class JsonSchemaTypeSingle extends JsonSchemaType
+    with JsonSchemaTypeSingleMappable {
+  final String value;
+  JsonSchemaTypeSingle(this.value);
+
+  static bool checkType(dynamic value) {
+    // primitive string form: "string" | "number" | ...
+    return value is String;
+  }
+}

--- a/packages/dart_mappable_schema/lib/src/json_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.dart
@@ -330,7 +330,15 @@ final class JsonSchema with JsonSchemaMappable {
 // additionalProperties: bool | schema
 @MappableClass(hook: JsonSchemaAdditionalPropertiesHook())
 sealed class JsonSchemaAdditionalProperties
-    with JsonSchemaAdditionalPropertiesMappable {}
+    with JsonSchemaAdditionalPropertiesMappable {
+  const JsonSchemaAdditionalProperties();
+
+  const factory JsonSchemaAdditionalProperties.bool(bool value) =
+      JsonSchemaAdditionalPropertiesForBool;
+
+  const factory JsonSchemaAdditionalProperties.schema(JsonSchema value) =
+      JsonSchemaAdditionalPropertiesForSchema;
+}
 
 @MappableClass(
   discriminatorValue: JsonSchemaAdditionalPropertiesForBool.checkType,
@@ -339,7 +347,7 @@ final class JsonSchemaAdditionalPropertiesForBool
     extends JsonSchemaAdditionalProperties
     with JsonSchemaAdditionalPropertiesForBoolMappable {
   final bool value;
-  JsonSchemaAdditionalPropertiesForBool(this.value);
+  const JsonSchemaAdditionalPropertiesForBool(this.value);
 
   static bool checkType(dynamic value) {
     return value is bool;
@@ -353,7 +361,7 @@ final class JsonSchemaAdditionalPropertiesForSchema
     extends JsonSchemaAdditionalProperties
     with JsonSchemaAdditionalPropertiesForSchemaMappable {
   final JsonSchema schema;
-  JsonSchemaAdditionalPropertiesForSchema(this.schema);
+  const JsonSchemaAdditionalPropertiesForSchema(this.schema);
 
   static bool checkType(dynamic value) {
     return value is Map<String, dynamic>;
@@ -362,13 +370,19 @@ final class JsonSchemaAdditionalPropertiesForSchema
 
 // items: schema | [schema]
 @MappableClass(hook: JsonSchemaItemsHook())
-sealed class JsonSchemaItems with JsonSchemaItemsMappable {}
+sealed class JsonSchemaItems with JsonSchemaItemsMappable {
+  const JsonSchemaItems();
+
+  const factory JsonSchemaItems.array(List<JsonSchema> value) =
+      JsonSchemaItemsArray;
+  const factory JsonSchemaItems.sign(JsonSchema value) = JsonSchemaItemsSingle;
+}
 
 @MappableClass(discriminatorValue: JsonSchemaItemsArray.checkType)
 final class JsonSchemaItemsArray extends JsonSchemaItems
     with JsonSchemaItemsArrayMappable {
   final List<JsonSchema> schemas;
-  JsonSchemaItemsArray(this.schemas);
+  const JsonSchemaItemsArray(this.schemas);
 
   static bool checkType(dynamic value) {
     // tuple form encoded as an array of schemas
@@ -380,7 +394,7 @@ final class JsonSchemaItemsArray extends JsonSchemaItems
 final class JsonSchemaItemsSingle extends JsonSchemaItems
     with JsonSchemaItemsSingleMappable {
   final JsonSchema schema;
-  JsonSchemaItemsSingle(this.schema);
+  const JsonSchemaItemsSingle(this.schema);
 
   static bool checkType(dynamic value) {
     // single item schema encoded as an object
@@ -392,6 +406,9 @@ final class JsonSchemaItemsSingle extends JsonSchemaItems
 @MappableClass(hook: JsonSchemaTypeHook())
 sealed class JsonSchemaType with JsonSchemaTypeMappable {
   const JsonSchemaType();
+
+  const factory JsonSchemaType.array(List<String> values) = JsonSchemaTypeArray;
+  const factory JsonSchemaType.single(String value) = JsonSchemaTypeSingle;
 }
 
 @MappableClass(discriminatorValue: JsonSchemaTypeArray.checkType)

--- a/packages/dart_mappable_schema/lib/src/json_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.dart
@@ -23,6 +23,9 @@ final class JsonSchema with JsonSchemaMappable {
   @MappableField(key: 'enum')
   final List<Object?>? enumValues;
 
+  @MappableField(key: 'const')
+  final Object? constValue;
+
   final JsonSchemaItems? items;
   final Map<String, JsonSchema>? properties;
   final List<String>? required;
@@ -79,6 +82,7 @@ final class JsonSchema with JsonSchemaMappable {
     this.description,
     this.type,
     this.enumValues,
+    this.constValue,
     this.items,
     this.properties,
     this.required,
@@ -143,7 +147,7 @@ final class JsonSchema with JsonSchemaMappable {
   factory JsonSchema.boolean({
     String? description,
     String? title,
-    Object? defaultValue,
+    bool? defaultValue,
   }) => JsonSchema(
     title: title,
     description: description,
@@ -185,7 +189,7 @@ final class JsonSchema with JsonSchemaMappable {
     bool? exclusiveMinimum,
     bool? exclusiveMaximum,
     num? multipleOf,
-    Object? defaultValue,
+    int? defaultValue,
   }) => JsonSchema(
     title: title,
     description: description,
@@ -223,7 +227,8 @@ final class JsonSchema with JsonSchemaMappable {
     bool? exclusiveMinimum,
     bool? exclusiveMaximum,
     num? multipleOf,
-    Object? defaultValue,
+    num? defaultValue,
+    num? constValue,
   }) => JsonSchema(
     title: title,
     description: description,
@@ -234,6 +239,7 @@ final class JsonSchema with JsonSchemaMappable {
     exclusiveMaximum: exclusiveMaximum,
     multipleOf: multipleOf,
     defaultValue: defaultValue,
+    constValue: constValue,
   );
 
   factory JsonSchema.object(
@@ -282,8 +288,9 @@ final class JsonSchema with JsonSchemaMappable {
     int? maxLength,
     String? pattern,
     String? format,
-    Object? defaultValue,
-    List<Object?>? enumValues,
+    String? defaultValue,
+    List<String>? enumValues,
+    String? constValue,
   }) => JsonSchema(
     title: title,
     description: description,
@@ -294,6 +301,7 @@ final class JsonSchema with JsonSchemaMappable {
     format: format,
     defaultValue: defaultValue,
     enumValues: enumValues,
+    constValue: constValue,
   );
 
   factory JsonSchema.tuple(

--- a/packages/dart_mappable_schema/lib/src/json_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.dart
@@ -19,6 +19,8 @@ final class JsonSchema with JsonSchemaMappable {
   final String? description;
 
   final JsonSchemaType? type;
+
+  @MappableField(key: 'enum')
   final List<Object?>? enumValues;
 
   final JsonSchemaItems? items;

--- a/packages/dart_mappable_schema/lib/src/json_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.dart
@@ -69,7 +69,7 @@ final class JsonSchema with JsonSchemaMappable {
   @MappableField(key: 'default')
   final Object? defaultValue;
 
-  JsonSchema({
+  const JsonSchema({
     this.id,
     this.schema,
     this.ref,
@@ -380,13 +380,15 @@ final class JsonSchemaItemsSingle extends JsonSchemaItems
 
 // type: string | [string]
 @MappableClass(hook: JsonSchemaTypeHook())
-sealed class JsonSchemaType with JsonSchemaTypeMappable {}
+sealed class JsonSchemaType with JsonSchemaTypeMappable {
+  const JsonSchemaType();
+}
 
 @MappableClass(discriminatorValue: JsonSchemaTypeArray.checkType)
 final class JsonSchemaTypeArray extends JsonSchemaType
     with JsonSchemaTypeArrayMappable {
   final List<String> values;
-  JsonSchemaTypeArray(this.values);
+  const JsonSchemaTypeArray(this.values);
 
   static bool checkType(dynamic value) {
     // list of primitive strings: ["string", "null", ...]
@@ -398,7 +400,7 @@ final class JsonSchemaTypeArray extends JsonSchemaType
 final class JsonSchemaTypeSingle extends JsonSchemaType
     with JsonSchemaTypeSingleMappable {
   final String value;
-  JsonSchemaTypeSingle(this.value);
+  const JsonSchemaTypeSingle(this.value);
 
   static bool checkType(dynamic value) {
     // primitive string form: "string" | "number" | ...

--- a/packages/dart_mappable_schema/lib/src/json_schema.mapper.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.mapper.dart
@@ -71,6 +71,13 @@ class JsonSchemaMapper extends ClassMapperBase<JsonSchema> {
     key: r'enum',
     opt: true,
   );
+  static Object? _$constValue(JsonSchema v) => v.constValue;
+  static const Field<JsonSchema, Object> _f$constValue = Field(
+    'constValue',
+    _$constValue,
+    key: r'const',
+    opt: true,
+  );
   static JsonSchemaItems? _$items(JsonSchema v) => v.items;
   static const Field<JsonSchema, JsonSchemaItems> _f$items = Field(
     'items',
@@ -259,6 +266,7 @@ class JsonSchemaMapper extends ClassMapperBase<JsonSchema> {
     #description: _f$description,
     #type: _f$type,
     #enumValues: _f$enumValues,
+    #constValue: _f$constValue,
     #items: _f$items,
     #properties: _f$properties,
     #required: _f$required,
@@ -302,6 +310,7 @@ class JsonSchemaMapper extends ClassMapperBase<JsonSchema> {
       description: data.dec(_f$description),
       type: data.dec(_f$type),
       enumValues: data.dec(_f$enumValues),
+      constValue: data.dec(_f$constValue),
       items: data.dec(_f$items),
       properties: data.dec(_f$properties),
       required: data.dec(_f$required),
@@ -449,6 +458,7 @@ abstract class JsonSchemaCopyWith<$R, $In extends JsonSchema, $Out>
     String? description,
     JsonSchemaType? type,
     List<Object?>? enumValues,
+    Object? constValue,
     JsonSchemaItems? items,
     Map<String, JsonSchema>? properties,
     List<String>? required,
@@ -632,6 +642,7 @@ class _JsonSchemaCopyWithImpl<$R, $Out>
     Object? description = $none,
     Object? type = $none,
     Object? enumValues = $none,
+    Object? constValue = $none,
     Object? items = $none,
     Object? properties = $none,
     Object? required = $none,
@@ -671,6 +682,7 @@ class _JsonSchemaCopyWithImpl<$R, $Out>
       if (description != $none) #description: description,
       if (type != $none) #type: type,
       if (enumValues != $none) #enumValues: enumValues,
+      if (constValue != $none) #constValue: constValue,
       if (items != $none) #items: items,
       if (properties != $none) #properties: properties,
       if (required != $none) #required: required,
@@ -713,6 +725,7 @@ class _JsonSchemaCopyWithImpl<$R, $Out>
     description: data.get(#description, or: $value.description),
     type: data.get(#type, or: $value.type),
     enumValues: data.get(#enumValues, or: $value.enumValues),
+    constValue: data.get(#constValue, or: $value.constValue),
     items: data.get(#items, or: $value.items),
     properties: data.get(#properties, or: $value.properties),
     required: data.get(#required, or: $value.required),

--- a/packages/dart_mappable_schema/lib/src/json_schema.mapper.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.mapper.dart
@@ -68,6 +68,7 @@ class JsonSchemaMapper extends ClassMapperBase<JsonSchema> {
   static const Field<JsonSchema, List<Object?>> _f$enumValues = Field(
     'enumValues',
     _$enumValues,
+    key: r'enum',
     opt: true,
   );
   static JsonSchemaItems? _$items(JsonSchema v) => v.items;

--- a/packages/dart_mappable_schema/lib/src/json_schema.mapper.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.mapper.dart
@@ -347,7 +347,7 @@ class JsonSchemaMapper extends ClassMapperBase<JsonSchema> {
   @override
   final Function instantiate = _instantiate;
 
-  static JsonSchema fromMap(Map<String, dynamic> map) {
+  static JsonSchema fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<JsonSchema>(map);
   }
 
@@ -363,7 +363,7 @@ mixin JsonSchemaMappable {
     );
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return JsonSchemaMapper.ensureInitialized().encodeMap<JsonSchema>(
       this as JsonSchema,
     );
@@ -798,7 +798,7 @@ class JsonSchemaTypeMapper extends ClassMapperBase<JsonSchemaType> {
   @override
   final Function instantiate = _instantiate;
 
-  static JsonSchemaType fromMap(Map<String, dynamic> map) {
+  static JsonSchemaType fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<JsonSchemaType>(map);
   }
 
@@ -809,7 +809,7 @@ class JsonSchemaTypeMapper extends ClassMapperBase<JsonSchemaType> {
 
 mixin JsonSchemaTypeMappable {
   String toJson();
-  Map<String, dynamic> toMap();
+  Map<dynamic, dynamic> toMap();
   JsonSchemaTypeCopyWith<JsonSchemaType, JsonSchemaType, JsonSchemaType>
   get copyWith;
 }
@@ -850,7 +850,7 @@ class JsonSchemaItemsMapper extends ClassMapperBase<JsonSchemaItems> {
   @override
   final Function instantiate = _instantiate;
 
-  static JsonSchemaItems fromMap(Map<String, dynamic> map) {
+  static JsonSchemaItems fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<JsonSchemaItems>(map);
   }
 
@@ -861,7 +861,7 @@ class JsonSchemaItemsMapper extends ClassMapperBase<JsonSchemaItems> {
 
 mixin JsonSchemaItemsMappable {
   String toJson();
-  Map<String, dynamic> toMap();
+  Map<dynamic, dynamic> toMap();
   JsonSchemaItemsCopyWith<JsonSchemaItems, JsonSchemaItems, JsonSchemaItems>
   get copyWith;
 }
@@ -905,7 +905,7 @@ class JsonSchemaAdditionalPropertiesMapper
   @override
   final Function instantiate = _instantiate;
 
-  static JsonSchemaAdditionalProperties fromMap(Map<String, dynamic> map) {
+  static JsonSchemaAdditionalProperties fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<JsonSchemaAdditionalProperties>(map);
   }
 
@@ -916,7 +916,7 @@ class JsonSchemaAdditionalPropertiesMapper
 
 mixin JsonSchemaAdditionalPropertiesMappable {
   String toJson();
-  Map<String, dynamic> toMap();
+  Map<dynamic, dynamic> toMap();
   JsonSchemaAdditionalPropertiesCopyWith<
     JsonSchemaAdditionalProperties,
     JsonSchemaAdditionalProperties,
@@ -986,7 +986,7 @@ class JsonSchemaAdditionalPropertiesForBoolMapper
   final Function instantiate = _instantiate;
 
   static JsonSchemaAdditionalPropertiesForBool fromMap(
-    Map<String, dynamic> map,
+    Map<dynamic, dynamic> map,
   ) {
     return ensureInitialized().decodeMap<JsonSchemaAdditionalPropertiesForBool>(
       map,
@@ -1007,7 +1007,7 @@ mixin JsonSchemaAdditionalPropertiesForBoolMappable {
         );
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return JsonSchemaAdditionalPropertiesForBoolMapper.ensureInitialized()
         .encodeMap<JsonSchemaAdditionalPropertiesForBool>(
           this as JsonSchemaAdditionalPropertiesForBool,
@@ -1159,7 +1159,7 @@ class JsonSchemaAdditionalPropertiesForSchemaMapper
   final Function instantiate = _instantiate;
 
   static JsonSchemaAdditionalPropertiesForSchema fromMap(
-    Map<String, dynamic> map,
+    Map<dynamic, dynamic> map,
   ) {
     return ensureInitialized()
         .decodeMap<JsonSchemaAdditionalPropertiesForSchema>(map);
@@ -1179,7 +1179,7 @@ mixin JsonSchemaAdditionalPropertiesForSchemaMappable {
         );
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return JsonSchemaAdditionalPropertiesForSchemaMapper.ensureInitialized()
         .encodeMap<JsonSchemaAdditionalPropertiesForSchema>(
           this as JsonSchemaAdditionalPropertiesForSchema,
@@ -1334,7 +1334,7 @@ class JsonSchemaItemsArrayMapper
   @override
   final Function instantiate = _instantiate;
 
-  static JsonSchemaItemsArray fromMap(Map<String, dynamic> map) {
+  static JsonSchemaItemsArray fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<JsonSchemaItemsArray>(map);
   }
 
@@ -1349,7 +1349,7 @@ mixin JsonSchemaItemsArrayMappable {
         .encodeJson<JsonSchemaItemsArray>(this as JsonSchemaItemsArray);
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return JsonSchemaItemsArrayMapper.ensureInitialized()
         .encodeMap<JsonSchemaItemsArray>(this as JsonSchemaItemsArray);
   }
@@ -1484,7 +1484,7 @@ class JsonSchemaItemsSingleMapper
   @override
   final Function instantiate = _instantiate;
 
-  static JsonSchemaItemsSingle fromMap(Map<String, dynamic> map) {
+  static JsonSchemaItemsSingle fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<JsonSchemaItemsSingle>(map);
   }
 
@@ -1499,7 +1499,7 @@ mixin JsonSchemaItemsSingleMappable {
         .encodeJson<JsonSchemaItemsSingle>(this as JsonSchemaItemsSingle);
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return JsonSchemaItemsSingleMapper.ensureInitialized()
         .encodeMap<JsonSchemaItemsSingle>(this as JsonSchemaItemsSingle);
   }
@@ -1626,7 +1626,7 @@ class JsonSchemaTypeArrayMapper
   @override
   final Function instantiate = _instantiate;
 
-  static JsonSchemaTypeArray fromMap(Map<String, dynamic> map) {
+  static JsonSchemaTypeArray fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<JsonSchemaTypeArray>(map);
   }
 
@@ -1641,7 +1641,7 @@ mixin JsonSchemaTypeArrayMappable {
         .encodeJson<JsonSchemaTypeArray>(this as JsonSchemaTypeArray);
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return JsonSchemaTypeArrayMapper.ensureInitialized()
         .encodeMap<JsonSchemaTypeArray>(this as JsonSchemaTypeArray);
   }
@@ -1772,7 +1772,7 @@ class JsonSchemaTypeSingleMapper
   @override
   final Function instantiate = _instantiate;
 
-  static JsonSchemaTypeSingle fromMap(Map<String, dynamic> map) {
+  static JsonSchemaTypeSingle fromMap(Map<dynamic, dynamic> map) {
     return ensureInitialized().decodeMap<JsonSchemaTypeSingle>(map);
   }
 
@@ -1787,7 +1787,7 @@ mixin JsonSchemaTypeSingleMappable {
         .encodeJson<JsonSchemaTypeSingle>(this as JsonSchemaTypeSingle);
   }
 
-  Map<String, dynamic> toMap() {
+  Map<dynamic, dynamic> toMap() {
     return JsonSchemaTypeSingleMapper.ensureInitialized()
         .encodeMap<JsonSchemaTypeSingle>(this as JsonSchemaTypeSingle);
   }

--- a/packages/dart_mappable_schema/lib/src/json_schema.mapper.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema.mapper.dart
@@ -1,0 +1,1855 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'json_schema.dart';
+
+class JsonSchemaMapper extends ClassMapperBase<JsonSchema> {
+  JsonSchemaMapper._();
+
+  static JsonSchemaMapper? _instance;
+  static JsonSchemaMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = JsonSchemaMapper._());
+      JsonSchemaTypeMapper.ensureInitialized();
+      JsonSchemaItemsMapper.ensureInitialized();
+      JsonSchemaMapper.ensureInitialized();
+      JsonSchemaAdditionalPropertiesMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchema';
+
+  static String? _$id(JsonSchema v) => v.id;
+  static const Field<JsonSchema, String> _f$id = Field(
+    'id',
+    _$id,
+    key: r'$id',
+    opt: true,
+  );
+  static String? _$schema(JsonSchema v) => v.schema;
+  static const Field<JsonSchema, String> _f$schema = Field(
+    'schema',
+    _$schema,
+    key: r'$schema',
+    opt: true,
+  );
+  static String? _$ref(JsonSchema v) => v.ref;
+  static const Field<JsonSchema, String> _f$ref = Field(
+    'ref',
+    _$ref,
+    key: r'$ref',
+    opt: true,
+  );
+  static String? _$title(JsonSchema v) => v.title;
+  static const Field<JsonSchema, String> _f$title = Field(
+    'title',
+    _$title,
+    opt: true,
+  );
+  static String? _$description(JsonSchema v) => v.description;
+  static const Field<JsonSchema, String> _f$description = Field(
+    'description',
+    _$description,
+    opt: true,
+  );
+  static JsonSchemaType? _$type(JsonSchema v) => v.type;
+  static const Field<JsonSchema, JsonSchemaType> _f$type = Field(
+    'type',
+    _$type,
+    opt: true,
+  );
+  static List<Object?>? _$enumValues(JsonSchema v) => v.enumValues;
+  static const Field<JsonSchema, List<Object?>> _f$enumValues = Field(
+    'enumValues',
+    _$enumValues,
+    opt: true,
+  );
+  static JsonSchemaItems? _$items(JsonSchema v) => v.items;
+  static const Field<JsonSchema, JsonSchemaItems> _f$items = Field(
+    'items',
+    _$items,
+    opt: true,
+  );
+  static Map<String, JsonSchema>? _$properties(JsonSchema v) => v.properties;
+  static const Field<JsonSchema, Map<String, JsonSchema>> _f$properties = Field(
+    'properties',
+    _$properties,
+    opt: true,
+  );
+  static List<String>? _$required(JsonSchema v) => v.required;
+  static const Field<JsonSchema, List<String>> _f$required = Field(
+    'required',
+    _$required,
+    opt: true,
+  );
+  static JsonSchemaAdditionalProperties? _$additionalProperties(JsonSchema v) =>
+      v.additionalProperties;
+  static const Field<JsonSchema, JsonSchemaAdditionalProperties>
+  _f$additionalProperties = Field(
+    'additionalProperties',
+    _$additionalProperties,
+    opt: true,
+  );
+  static Map<String, JsonSchema>? _$patternProperties(JsonSchema v) =>
+      v.patternProperties;
+  static const Field<JsonSchema, Map<String, JsonSchema>> _f$patternProperties =
+      Field('patternProperties', _$patternProperties, opt: true);
+  static Map<String, JsonSchema>? _$definitions(JsonSchema v) => v.definitions;
+  static const Field<JsonSchema, Map<String, JsonSchema>> _f$definitions =
+      Field('definitions', _$definitions, opt: true);
+  static List<JsonSchema>? _$allOf(JsonSchema v) => v.allOf;
+  static const Field<JsonSchema, List<JsonSchema>> _f$allOf = Field(
+    'allOf',
+    _$allOf,
+    opt: true,
+  );
+  static List<JsonSchema>? _$anyOf(JsonSchema v) => v.anyOf;
+  static const Field<JsonSchema, List<JsonSchema>> _f$anyOf = Field(
+    'anyOf',
+    _$anyOf,
+    opt: true,
+  );
+  static List<JsonSchema>? _$oneOf(JsonSchema v) => v.oneOf;
+  static const Field<JsonSchema, List<JsonSchema>> _f$oneOf = Field(
+    'oneOf',
+    _$oneOf,
+    opt: true,
+  );
+  static JsonSchema? _$not(JsonSchema v) => v.not;
+  static const Field<JsonSchema, JsonSchema> _f$not = Field(
+    'not',
+    _$not,
+    opt: true,
+  );
+  static JsonSchema? _$ifSchema(JsonSchema v) => v.ifSchema;
+  static const Field<JsonSchema, JsonSchema> _f$ifSchema = Field(
+    'ifSchema',
+    _$ifSchema,
+    opt: true,
+  );
+  static JsonSchema? _$thenSchema(JsonSchema v) => v.thenSchema;
+  static const Field<JsonSchema, JsonSchema> _f$thenSchema = Field(
+    'thenSchema',
+    _$thenSchema,
+    opt: true,
+  );
+  static JsonSchema? _$elseSchema(JsonSchema v) => v.elseSchema;
+  static const Field<JsonSchema, JsonSchema> _f$elseSchema = Field(
+    'elseSchema',
+    _$elseSchema,
+    opt: true,
+  );
+  static num? _$multipleOf(JsonSchema v) => v.multipleOf;
+  static const Field<JsonSchema, num> _f$multipleOf = Field(
+    'multipleOf',
+    _$multipleOf,
+    opt: true,
+  );
+  static num? _$maximum(JsonSchema v) => v.maximum;
+  static const Field<JsonSchema, num> _f$maximum = Field(
+    'maximum',
+    _$maximum,
+    opt: true,
+  );
+  static bool? _$exclusiveMaximum(JsonSchema v) => v.exclusiveMaximum;
+  static const Field<JsonSchema, bool> _f$exclusiveMaximum = Field(
+    'exclusiveMaximum',
+    _$exclusiveMaximum,
+    opt: true,
+  );
+  static num? _$minimum(JsonSchema v) => v.minimum;
+  static const Field<JsonSchema, num> _f$minimum = Field(
+    'minimum',
+    _$minimum,
+    opt: true,
+  );
+  static bool? _$exclusiveMinimum(JsonSchema v) => v.exclusiveMinimum;
+  static const Field<JsonSchema, bool> _f$exclusiveMinimum = Field(
+    'exclusiveMinimum',
+    _$exclusiveMinimum,
+    opt: true,
+  );
+  static int? _$maxLength(JsonSchema v) => v.maxLength;
+  static const Field<JsonSchema, int> _f$maxLength = Field(
+    'maxLength',
+    _$maxLength,
+    opt: true,
+  );
+  static int? _$minLength(JsonSchema v) => v.minLength;
+  static const Field<JsonSchema, int> _f$minLength = Field(
+    'minLength',
+    _$minLength,
+    opt: true,
+  );
+  static String? _$pattern(JsonSchema v) => v.pattern;
+  static const Field<JsonSchema, String> _f$pattern = Field(
+    'pattern',
+    _$pattern,
+    opt: true,
+  );
+  static String? _$format(JsonSchema v) => v.format;
+  static const Field<JsonSchema, String> _f$format = Field(
+    'format',
+    _$format,
+    opt: true,
+  );
+  static int? _$maxItems(JsonSchema v) => v.maxItems;
+  static const Field<JsonSchema, int> _f$maxItems = Field(
+    'maxItems',
+    _$maxItems,
+    opt: true,
+  );
+  static int? _$minItems(JsonSchema v) => v.minItems;
+  static const Field<JsonSchema, int> _f$minItems = Field(
+    'minItems',
+    _$minItems,
+    opt: true,
+  );
+  static bool? _$uniqueItems(JsonSchema v) => v.uniqueItems;
+  static const Field<JsonSchema, bool> _f$uniqueItems = Field(
+    'uniqueItems',
+    _$uniqueItems,
+    opt: true,
+  );
+  static List<Object?>? _$contains(JsonSchema v) => v.contains;
+  static const Field<JsonSchema, List<Object?>> _f$contains = Field(
+    'contains',
+    _$contains,
+    opt: true,
+  );
+  static int? _$maxProperties(JsonSchema v) => v.maxProperties;
+  static const Field<JsonSchema, int> _f$maxProperties = Field(
+    'maxProperties',
+    _$maxProperties,
+    opt: true,
+  );
+  static int? _$minProperties(JsonSchema v) => v.minProperties;
+  static const Field<JsonSchema, int> _f$minProperties = Field(
+    'minProperties',
+    _$minProperties,
+    opt: true,
+  );
+  static List<String>? _$dependencies(JsonSchema v) => v.dependencies;
+  static const Field<JsonSchema, List<String>> _f$dependencies = Field(
+    'dependencies',
+    _$dependencies,
+    opt: true,
+  );
+  static Object? _$defaultValue(JsonSchema v) => v.defaultValue;
+  static const Field<JsonSchema, Object> _f$defaultValue = Field(
+    'defaultValue',
+    _$defaultValue,
+    key: r'default',
+    opt: true,
+  );
+
+  @override
+  final MappableFields<JsonSchema> fields = const {
+    #id: _f$id,
+    #schema: _f$schema,
+    #ref: _f$ref,
+    #title: _f$title,
+    #description: _f$description,
+    #type: _f$type,
+    #enumValues: _f$enumValues,
+    #items: _f$items,
+    #properties: _f$properties,
+    #required: _f$required,
+    #additionalProperties: _f$additionalProperties,
+    #patternProperties: _f$patternProperties,
+    #definitions: _f$definitions,
+    #allOf: _f$allOf,
+    #anyOf: _f$anyOf,
+    #oneOf: _f$oneOf,
+    #not: _f$not,
+    #ifSchema: _f$ifSchema,
+    #thenSchema: _f$thenSchema,
+    #elseSchema: _f$elseSchema,
+    #multipleOf: _f$multipleOf,
+    #maximum: _f$maximum,
+    #exclusiveMaximum: _f$exclusiveMaximum,
+    #minimum: _f$minimum,
+    #exclusiveMinimum: _f$exclusiveMinimum,
+    #maxLength: _f$maxLength,
+    #minLength: _f$minLength,
+    #pattern: _f$pattern,
+    #format: _f$format,
+    #maxItems: _f$maxItems,
+    #minItems: _f$minItems,
+    #uniqueItems: _f$uniqueItems,
+    #contains: _f$contains,
+    #maxProperties: _f$maxProperties,
+    #minProperties: _f$minProperties,
+    #dependencies: _f$dependencies,
+    #defaultValue: _f$defaultValue,
+  };
+  @override
+  final bool ignoreNull = true;
+
+  static JsonSchema _instantiate(DecodingData data) {
+    return JsonSchema(
+      id: data.dec(_f$id),
+      schema: data.dec(_f$schema),
+      ref: data.dec(_f$ref),
+      title: data.dec(_f$title),
+      description: data.dec(_f$description),
+      type: data.dec(_f$type),
+      enumValues: data.dec(_f$enumValues),
+      items: data.dec(_f$items),
+      properties: data.dec(_f$properties),
+      required: data.dec(_f$required),
+      additionalProperties: data.dec(_f$additionalProperties),
+      patternProperties: data.dec(_f$patternProperties),
+      definitions: data.dec(_f$definitions),
+      allOf: data.dec(_f$allOf),
+      anyOf: data.dec(_f$anyOf),
+      oneOf: data.dec(_f$oneOf),
+      not: data.dec(_f$not),
+      ifSchema: data.dec(_f$ifSchema),
+      thenSchema: data.dec(_f$thenSchema),
+      elseSchema: data.dec(_f$elseSchema),
+      multipleOf: data.dec(_f$multipleOf),
+      maximum: data.dec(_f$maximum),
+      exclusiveMaximum: data.dec(_f$exclusiveMaximum),
+      minimum: data.dec(_f$minimum),
+      exclusiveMinimum: data.dec(_f$exclusiveMinimum),
+      maxLength: data.dec(_f$maxLength),
+      minLength: data.dec(_f$minLength),
+      pattern: data.dec(_f$pattern),
+      format: data.dec(_f$format),
+      maxItems: data.dec(_f$maxItems),
+      minItems: data.dec(_f$minItems),
+      uniqueItems: data.dec(_f$uniqueItems),
+      contains: data.dec(_f$contains),
+      maxProperties: data.dec(_f$maxProperties),
+      minProperties: data.dec(_f$minProperties),
+      dependencies: data.dec(_f$dependencies),
+      defaultValue: data.dec(_f$defaultValue),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchema fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<JsonSchema>(map);
+  }
+
+  static JsonSchema fromJson(String json) {
+    return ensureInitialized().decodeJson<JsonSchema>(json);
+  }
+}
+
+mixin JsonSchemaMappable {
+  String toJson() {
+    return JsonSchemaMapper.ensureInitialized().encodeJson<JsonSchema>(
+      this as JsonSchema,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return JsonSchemaMapper.ensureInitialized().encodeMap<JsonSchema>(
+      this as JsonSchema,
+    );
+  }
+
+  JsonSchemaCopyWith<JsonSchema, JsonSchema, JsonSchema> get copyWith =>
+      _JsonSchemaCopyWithImpl<JsonSchema, JsonSchema>(
+        this as JsonSchema,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return JsonSchemaMapper.ensureInitialized().stringifyValue(
+      this as JsonSchema,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return JsonSchemaMapper.ensureInitialized().equalsValue(
+      this as JsonSchema,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return JsonSchemaMapper.ensureInitialized().hashValue(this as JsonSchema);
+  }
+}
+
+extension JsonSchemaValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, JsonSchema, $Out> {
+  JsonSchemaCopyWith<$R, JsonSchema, $Out> get $asJsonSchema =>
+      $base.as((v, t, t2) => _JsonSchemaCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class JsonSchemaCopyWith<$R, $In extends JsonSchema, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  JsonSchemaTypeCopyWith<$R, JsonSchemaType, JsonSchemaType>? get type;
+  ListCopyWith<$R, Object?, ObjectCopyWith<$R, Object?, Object?>?>?
+  get enumValues;
+  JsonSchemaItemsCopyWith<$R, JsonSchemaItems, JsonSchemaItems>? get items;
+  MapCopyWith<
+    $R,
+    String,
+    JsonSchema,
+    JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>
+  >?
+  get properties;
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>? get required;
+  JsonSchemaAdditionalPropertiesCopyWith<
+    $R,
+    JsonSchemaAdditionalProperties,
+    JsonSchemaAdditionalProperties
+  >?
+  get additionalProperties;
+  MapCopyWith<
+    $R,
+    String,
+    JsonSchema,
+    JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>
+  >?
+  get patternProperties;
+  MapCopyWith<
+    $R,
+    String,
+    JsonSchema,
+    JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>
+  >?
+  get definitions;
+  ListCopyWith<$R, JsonSchema, JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>>?
+  get allOf;
+  ListCopyWith<$R, JsonSchema, JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>>?
+  get anyOf;
+  ListCopyWith<$R, JsonSchema, JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>>?
+  get oneOf;
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>? get not;
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>? get ifSchema;
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>? get thenSchema;
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>? get elseSchema;
+  ListCopyWith<$R, Object?, ObjectCopyWith<$R, Object?, Object?>?>?
+  get contains;
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>?
+  get dependencies;
+  $R call({
+    String? id,
+    String? schema,
+    String? ref,
+    String? title,
+    String? description,
+    JsonSchemaType? type,
+    List<Object?>? enumValues,
+    JsonSchemaItems? items,
+    Map<String, JsonSchema>? properties,
+    List<String>? required,
+    JsonSchemaAdditionalProperties? additionalProperties,
+    Map<String, JsonSchema>? patternProperties,
+    Map<String, JsonSchema>? definitions,
+    List<JsonSchema>? allOf,
+    List<JsonSchema>? anyOf,
+    List<JsonSchema>? oneOf,
+    JsonSchema? not,
+    JsonSchema? ifSchema,
+    JsonSchema? thenSchema,
+    JsonSchema? elseSchema,
+    num? multipleOf,
+    num? maximum,
+    bool? exclusiveMaximum,
+    num? minimum,
+    bool? exclusiveMinimum,
+    int? maxLength,
+    int? minLength,
+    String? pattern,
+    String? format,
+    int? maxItems,
+    int? minItems,
+    bool? uniqueItems,
+    List<Object?>? contains,
+    int? maxProperties,
+    int? minProperties,
+    List<String>? dependencies,
+    Object? defaultValue,
+  });
+  JsonSchemaCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _JsonSchemaCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, JsonSchema, $Out>
+    implements JsonSchemaCopyWith<$R, JsonSchema, $Out> {
+  _JsonSchemaCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<JsonSchema> $mapper =
+      JsonSchemaMapper.ensureInitialized();
+  @override
+  JsonSchemaTypeCopyWith<$R, JsonSchemaType, JsonSchemaType>? get type =>
+      $value.type?.copyWith.$chain((v) => call(type: v));
+  @override
+  ListCopyWith<$R, Object?, ObjectCopyWith<$R, Object?, Object?>?>?
+  get enumValues => $value.enumValues != null
+      ? ListCopyWith(
+          $value.enumValues!,
+          (v, t) => ObjectCopyWith(v, $identity, t),
+          (v) => call(enumValues: v),
+        )
+      : null;
+  @override
+  JsonSchemaItemsCopyWith<$R, JsonSchemaItems, JsonSchemaItems>? get items =>
+      $value.items?.copyWith.$chain((v) => call(items: v));
+  @override
+  MapCopyWith<
+    $R,
+    String,
+    JsonSchema,
+    JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>
+  >?
+  get properties => $value.properties != null
+      ? MapCopyWith(
+          $value.properties!,
+          (v, t) => v.copyWith.$chain(t),
+          (v) => call(properties: v),
+        )
+      : null;
+  @override
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>? get required =>
+      $value.required != null
+      ? ListCopyWith(
+          $value.required!,
+          (v, t) => ObjectCopyWith(v, $identity, t),
+          (v) => call(required: v),
+        )
+      : null;
+  @override
+  JsonSchemaAdditionalPropertiesCopyWith<
+    $R,
+    JsonSchemaAdditionalProperties,
+    JsonSchemaAdditionalProperties
+  >?
+  get additionalProperties => $value.additionalProperties?.copyWith.$chain(
+    (v) => call(additionalProperties: v),
+  );
+  @override
+  MapCopyWith<
+    $R,
+    String,
+    JsonSchema,
+    JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>
+  >?
+  get patternProperties => $value.patternProperties != null
+      ? MapCopyWith(
+          $value.patternProperties!,
+          (v, t) => v.copyWith.$chain(t),
+          (v) => call(patternProperties: v),
+        )
+      : null;
+  @override
+  MapCopyWith<
+    $R,
+    String,
+    JsonSchema,
+    JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>
+  >?
+  get definitions => $value.definitions != null
+      ? MapCopyWith(
+          $value.definitions!,
+          (v, t) => v.copyWith.$chain(t),
+          (v) => call(definitions: v),
+        )
+      : null;
+  @override
+  ListCopyWith<$R, JsonSchema, JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>>?
+  get allOf => $value.allOf != null
+      ? ListCopyWith(
+          $value.allOf!,
+          (v, t) => v.copyWith.$chain(t),
+          (v) => call(allOf: v),
+        )
+      : null;
+  @override
+  ListCopyWith<$R, JsonSchema, JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>>?
+  get anyOf => $value.anyOf != null
+      ? ListCopyWith(
+          $value.anyOf!,
+          (v, t) => v.copyWith.$chain(t),
+          (v) => call(anyOf: v),
+        )
+      : null;
+  @override
+  ListCopyWith<$R, JsonSchema, JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>>?
+  get oneOf => $value.oneOf != null
+      ? ListCopyWith(
+          $value.oneOf!,
+          (v, t) => v.copyWith.$chain(t),
+          (v) => call(oneOf: v),
+        )
+      : null;
+  @override
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>? get not =>
+      $value.not?.copyWith.$chain((v) => call(not: v));
+  @override
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>? get ifSchema =>
+      $value.ifSchema?.copyWith.$chain((v) => call(ifSchema: v));
+  @override
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>? get thenSchema =>
+      $value.thenSchema?.copyWith.$chain((v) => call(thenSchema: v));
+  @override
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>? get elseSchema =>
+      $value.elseSchema?.copyWith.$chain((v) => call(elseSchema: v));
+  @override
+  ListCopyWith<$R, Object?, ObjectCopyWith<$R, Object?, Object?>?>?
+  get contains => $value.contains != null
+      ? ListCopyWith(
+          $value.contains!,
+          (v, t) => ObjectCopyWith(v, $identity, t),
+          (v) => call(contains: v),
+        )
+      : null;
+  @override
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>>?
+  get dependencies => $value.dependencies != null
+      ? ListCopyWith(
+          $value.dependencies!,
+          (v, t) => ObjectCopyWith(v, $identity, t),
+          (v) => call(dependencies: v),
+        )
+      : null;
+  @override
+  $R call({
+    Object? id = $none,
+    Object? schema = $none,
+    Object? ref = $none,
+    Object? title = $none,
+    Object? description = $none,
+    Object? type = $none,
+    Object? enumValues = $none,
+    Object? items = $none,
+    Object? properties = $none,
+    Object? required = $none,
+    Object? additionalProperties = $none,
+    Object? patternProperties = $none,
+    Object? definitions = $none,
+    Object? allOf = $none,
+    Object? anyOf = $none,
+    Object? oneOf = $none,
+    Object? not = $none,
+    Object? ifSchema = $none,
+    Object? thenSchema = $none,
+    Object? elseSchema = $none,
+    Object? multipleOf = $none,
+    Object? maximum = $none,
+    Object? exclusiveMaximum = $none,
+    Object? minimum = $none,
+    Object? exclusiveMinimum = $none,
+    Object? maxLength = $none,
+    Object? minLength = $none,
+    Object? pattern = $none,
+    Object? format = $none,
+    Object? maxItems = $none,
+    Object? minItems = $none,
+    Object? uniqueItems = $none,
+    Object? contains = $none,
+    Object? maxProperties = $none,
+    Object? minProperties = $none,
+    Object? dependencies = $none,
+    Object? defaultValue = $none,
+  }) => $apply(
+    FieldCopyWithData({
+      if (id != $none) #id: id,
+      if (schema != $none) #schema: schema,
+      if (ref != $none) #ref: ref,
+      if (title != $none) #title: title,
+      if (description != $none) #description: description,
+      if (type != $none) #type: type,
+      if (enumValues != $none) #enumValues: enumValues,
+      if (items != $none) #items: items,
+      if (properties != $none) #properties: properties,
+      if (required != $none) #required: required,
+      if (additionalProperties != $none)
+        #additionalProperties: additionalProperties,
+      if (patternProperties != $none) #patternProperties: patternProperties,
+      if (definitions != $none) #definitions: definitions,
+      if (allOf != $none) #allOf: allOf,
+      if (anyOf != $none) #anyOf: anyOf,
+      if (oneOf != $none) #oneOf: oneOf,
+      if (not != $none) #not: not,
+      if (ifSchema != $none) #ifSchema: ifSchema,
+      if (thenSchema != $none) #thenSchema: thenSchema,
+      if (elseSchema != $none) #elseSchema: elseSchema,
+      if (multipleOf != $none) #multipleOf: multipleOf,
+      if (maximum != $none) #maximum: maximum,
+      if (exclusiveMaximum != $none) #exclusiveMaximum: exclusiveMaximum,
+      if (minimum != $none) #minimum: minimum,
+      if (exclusiveMinimum != $none) #exclusiveMinimum: exclusiveMinimum,
+      if (maxLength != $none) #maxLength: maxLength,
+      if (minLength != $none) #minLength: minLength,
+      if (pattern != $none) #pattern: pattern,
+      if (format != $none) #format: format,
+      if (maxItems != $none) #maxItems: maxItems,
+      if (minItems != $none) #minItems: minItems,
+      if (uniqueItems != $none) #uniqueItems: uniqueItems,
+      if (contains != $none) #contains: contains,
+      if (maxProperties != $none) #maxProperties: maxProperties,
+      if (minProperties != $none) #minProperties: minProperties,
+      if (dependencies != $none) #dependencies: dependencies,
+      if (defaultValue != $none) #defaultValue: defaultValue,
+    }),
+  );
+  @override
+  JsonSchema $make(CopyWithData data) => JsonSchema(
+    id: data.get(#id, or: $value.id),
+    schema: data.get(#schema, or: $value.schema),
+    ref: data.get(#ref, or: $value.ref),
+    title: data.get(#title, or: $value.title),
+    description: data.get(#description, or: $value.description),
+    type: data.get(#type, or: $value.type),
+    enumValues: data.get(#enumValues, or: $value.enumValues),
+    items: data.get(#items, or: $value.items),
+    properties: data.get(#properties, or: $value.properties),
+    required: data.get(#required, or: $value.required),
+    additionalProperties: data.get(
+      #additionalProperties,
+      or: $value.additionalProperties,
+    ),
+    patternProperties: data.get(
+      #patternProperties,
+      or: $value.patternProperties,
+    ),
+    definitions: data.get(#definitions, or: $value.definitions),
+    allOf: data.get(#allOf, or: $value.allOf),
+    anyOf: data.get(#anyOf, or: $value.anyOf),
+    oneOf: data.get(#oneOf, or: $value.oneOf),
+    not: data.get(#not, or: $value.not),
+    ifSchema: data.get(#ifSchema, or: $value.ifSchema),
+    thenSchema: data.get(#thenSchema, or: $value.thenSchema),
+    elseSchema: data.get(#elseSchema, or: $value.elseSchema),
+    multipleOf: data.get(#multipleOf, or: $value.multipleOf),
+    maximum: data.get(#maximum, or: $value.maximum),
+    exclusiveMaximum: data.get(#exclusiveMaximum, or: $value.exclusiveMaximum),
+    minimum: data.get(#minimum, or: $value.minimum),
+    exclusiveMinimum: data.get(#exclusiveMinimum, or: $value.exclusiveMinimum),
+    maxLength: data.get(#maxLength, or: $value.maxLength),
+    minLength: data.get(#minLength, or: $value.minLength),
+    pattern: data.get(#pattern, or: $value.pattern),
+    format: data.get(#format, or: $value.format),
+    maxItems: data.get(#maxItems, or: $value.maxItems),
+    minItems: data.get(#minItems, or: $value.minItems),
+    uniqueItems: data.get(#uniqueItems, or: $value.uniqueItems),
+    contains: data.get(#contains, or: $value.contains),
+    maxProperties: data.get(#maxProperties, or: $value.maxProperties),
+    minProperties: data.get(#minProperties, or: $value.minProperties),
+    dependencies: data.get(#dependencies, or: $value.dependencies),
+    defaultValue: data.get(#defaultValue, or: $value.defaultValue),
+  );
+
+  @override
+  JsonSchemaCopyWith<$R2, JsonSchema, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _JsonSchemaCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class JsonSchemaTypeMapper extends ClassMapperBase<JsonSchemaType> {
+  JsonSchemaTypeMapper._();
+
+  static JsonSchemaTypeMapper? _instance;
+  static JsonSchemaTypeMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = JsonSchemaTypeMapper._());
+      JsonSchemaTypeArrayMapper.ensureInitialized();
+      JsonSchemaTypeSingleMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaType';
+
+  @override
+  final MappableFields<JsonSchemaType> fields = const {};
+
+  @override
+  final MappingHook hook = const JsonSchemaTypeHook();
+  static JsonSchemaType _instantiate(DecodingData data) {
+    throw MapperException.missingConstructor('JsonSchemaType');
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaType fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<JsonSchemaType>(map);
+  }
+
+  static JsonSchemaType fromJson(String json) {
+    return ensureInitialized().decodeJson<JsonSchemaType>(json);
+  }
+}
+
+mixin JsonSchemaTypeMappable {
+  String toJson();
+  Map<String, dynamic> toMap();
+  JsonSchemaTypeCopyWith<JsonSchemaType, JsonSchemaType, JsonSchemaType>
+  get copyWith;
+}
+
+abstract class JsonSchemaTypeCopyWith<$R, $In extends JsonSchemaType, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call();
+  JsonSchemaTypeCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class JsonSchemaItemsMapper extends ClassMapperBase<JsonSchemaItems> {
+  JsonSchemaItemsMapper._();
+
+  static JsonSchemaItemsMapper? _instance;
+  static JsonSchemaItemsMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = JsonSchemaItemsMapper._());
+      JsonSchemaItemsArrayMapper.ensureInitialized();
+      JsonSchemaItemsSingleMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaItems';
+
+  @override
+  final MappableFields<JsonSchemaItems> fields = const {};
+
+  @override
+  final MappingHook hook = const JsonSchemaItemsHook();
+  static JsonSchemaItems _instantiate(DecodingData data) {
+    throw MapperException.missingConstructor('JsonSchemaItems');
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaItems fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<JsonSchemaItems>(map);
+  }
+
+  static JsonSchemaItems fromJson(String json) {
+    return ensureInitialized().decodeJson<JsonSchemaItems>(json);
+  }
+}
+
+mixin JsonSchemaItemsMappable {
+  String toJson();
+  Map<String, dynamic> toMap();
+  JsonSchemaItemsCopyWith<JsonSchemaItems, JsonSchemaItems, JsonSchemaItems>
+  get copyWith;
+}
+
+abstract class JsonSchemaItemsCopyWith<$R, $In extends JsonSchemaItems, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call();
+  JsonSchemaItemsCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class JsonSchemaAdditionalPropertiesMapper
+    extends ClassMapperBase<JsonSchemaAdditionalProperties> {
+  JsonSchemaAdditionalPropertiesMapper._();
+
+  static JsonSchemaAdditionalPropertiesMapper? _instance;
+  static JsonSchemaAdditionalPropertiesMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(
+        _instance = JsonSchemaAdditionalPropertiesMapper._(),
+      );
+      JsonSchemaAdditionalPropertiesForBoolMapper.ensureInitialized();
+      JsonSchemaAdditionalPropertiesForSchemaMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaAdditionalProperties';
+
+  @override
+  final MappableFields<JsonSchemaAdditionalProperties> fields = const {};
+
+  @override
+  final MappingHook hook = const JsonSchemaAdditionalPropertiesHook();
+  static JsonSchemaAdditionalProperties _instantiate(DecodingData data) {
+    throw MapperException.missingConstructor('JsonSchemaAdditionalProperties');
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaAdditionalProperties fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<JsonSchemaAdditionalProperties>(map);
+  }
+
+  static JsonSchemaAdditionalProperties fromJson(String json) {
+    return ensureInitialized().decodeJson<JsonSchemaAdditionalProperties>(json);
+  }
+}
+
+mixin JsonSchemaAdditionalPropertiesMappable {
+  String toJson();
+  Map<String, dynamic> toMap();
+  JsonSchemaAdditionalPropertiesCopyWith<
+    JsonSchemaAdditionalProperties,
+    JsonSchemaAdditionalProperties,
+    JsonSchemaAdditionalProperties
+  >
+  get copyWith;
+}
+
+abstract class JsonSchemaAdditionalPropertiesCopyWith<
+  $R,
+  $In extends JsonSchemaAdditionalProperties,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call();
+  JsonSchemaAdditionalPropertiesCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class JsonSchemaAdditionalPropertiesForBoolMapper
+    extends SubClassMapperBase<JsonSchemaAdditionalPropertiesForBool> {
+  JsonSchemaAdditionalPropertiesForBoolMapper._();
+
+  static JsonSchemaAdditionalPropertiesForBoolMapper? _instance;
+  static JsonSchemaAdditionalPropertiesForBoolMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(
+        _instance = JsonSchemaAdditionalPropertiesForBoolMapper._(),
+      );
+      JsonSchemaAdditionalPropertiesMapper.ensureInitialized().addSubMapper(
+        _instance!,
+      );
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaAdditionalPropertiesForBool';
+
+  static bool _$value(JsonSchemaAdditionalPropertiesForBool v) => v.value;
+  static const Field<JsonSchemaAdditionalPropertiesForBool, bool> _f$value =
+      Field('value', _$value);
+
+  @override
+  final MappableFields<JsonSchemaAdditionalPropertiesForBool> fields = const {
+    #value: _f$value,
+  };
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue =
+      JsonSchemaAdditionalPropertiesForBool.checkType;
+  @override
+  late final ClassMapperBase superMapper =
+      JsonSchemaAdditionalPropertiesMapper.ensureInitialized();
+
+  @override
+  final MappingHook superHook = const JsonSchemaAdditionalPropertiesHook();
+
+  static JsonSchemaAdditionalPropertiesForBool _instantiate(DecodingData data) {
+    return JsonSchemaAdditionalPropertiesForBool(data.dec(_f$value));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaAdditionalPropertiesForBool fromMap(
+    Map<String, dynamic> map,
+  ) {
+    return ensureInitialized().decodeMap<JsonSchemaAdditionalPropertiesForBool>(
+      map,
+    );
+  }
+
+  static JsonSchemaAdditionalPropertiesForBool fromJson(String json) {
+    return ensureInitialized()
+        .decodeJson<JsonSchemaAdditionalPropertiesForBool>(json);
+  }
+}
+
+mixin JsonSchemaAdditionalPropertiesForBoolMappable {
+  String toJson() {
+    return JsonSchemaAdditionalPropertiesForBoolMapper.ensureInitialized()
+        .encodeJson<JsonSchemaAdditionalPropertiesForBool>(
+          this as JsonSchemaAdditionalPropertiesForBool,
+        );
+  }
+
+  Map<String, dynamic> toMap() {
+    return JsonSchemaAdditionalPropertiesForBoolMapper.ensureInitialized()
+        .encodeMap<JsonSchemaAdditionalPropertiesForBool>(
+          this as JsonSchemaAdditionalPropertiesForBool,
+        );
+  }
+
+  JsonSchemaAdditionalPropertiesForBoolCopyWith<
+    JsonSchemaAdditionalPropertiesForBool,
+    JsonSchemaAdditionalPropertiesForBool,
+    JsonSchemaAdditionalPropertiesForBool
+  >
+  get copyWith =>
+      _JsonSchemaAdditionalPropertiesForBoolCopyWithImpl<
+        JsonSchemaAdditionalPropertiesForBool,
+        JsonSchemaAdditionalPropertiesForBool
+      >(this as JsonSchemaAdditionalPropertiesForBool, $identity, $identity);
+  @override
+  String toString() {
+    return JsonSchemaAdditionalPropertiesForBoolMapper.ensureInitialized()
+        .stringifyValue(this as JsonSchemaAdditionalPropertiesForBool);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return JsonSchemaAdditionalPropertiesForBoolMapper.ensureInitialized()
+        .equalsValue(this as JsonSchemaAdditionalPropertiesForBool, other);
+  }
+
+  @override
+  int get hashCode {
+    return JsonSchemaAdditionalPropertiesForBoolMapper.ensureInitialized()
+        .hashValue(this as JsonSchemaAdditionalPropertiesForBool);
+  }
+}
+
+extension JsonSchemaAdditionalPropertiesForBoolValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, JsonSchemaAdditionalPropertiesForBool, $Out> {
+  JsonSchemaAdditionalPropertiesForBoolCopyWith<
+    $R,
+    JsonSchemaAdditionalPropertiesForBool,
+    $Out
+  >
+  get $asJsonSchemaAdditionalPropertiesForBool => $base.as(
+    (v, t, t2) =>
+        _JsonSchemaAdditionalPropertiesForBoolCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class JsonSchemaAdditionalPropertiesForBoolCopyWith<
+  $R,
+  $In extends JsonSchemaAdditionalPropertiesForBool,
+  $Out
+>
+    implements JsonSchemaAdditionalPropertiesCopyWith<$R, $In, $Out> {
+  @override
+  $R call({bool? value});
+  JsonSchemaAdditionalPropertiesForBoolCopyWith<$R2, $In, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _JsonSchemaAdditionalPropertiesForBoolCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, JsonSchemaAdditionalPropertiesForBool, $Out>
+    implements
+        JsonSchemaAdditionalPropertiesForBoolCopyWith<
+          $R,
+          JsonSchemaAdditionalPropertiesForBool,
+          $Out
+        > {
+  _JsonSchemaAdditionalPropertiesForBoolCopyWithImpl(
+    super.value,
+    super.then,
+    super.then2,
+  );
+
+  @override
+  late final ClassMapperBase<JsonSchemaAdditionalPropertiesForBool> $mapper =
+      JsonSchemaAdditionalPropertiesForBoolMapper.ensureInitialized();
+  @override
+  $R call({bool? value}) =>
+      $apply(FieldCopyWithData({if (value != null) #value: value}));
+  @override
+  JsonSchemaAdditionalPropertiesForBool $make(CopyWithData data) =>
+      JsonSchemaAdditionalPropertiesForBool(data.get(#value, or: $value.value));
+
+  @override
+  JsonSchemaAdditionalPropertiesForBoolCopyWith<
+    $R2,
+    JsonSchemaAdditionalPropertiesForBool,
+    $Out2
+  >
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _JsonSchemaAdditionalPropertiesForBoolCopyWithImpl<$R2, $Out2>(
+        $value,
+        $cast,
+        t,
+      );
+}
+
+class JsonSchemaAdditionalPropertiesForSchemaMapper
+    extends SubClassMapperBase<JsonSchemaAdditionalPropertiesForSchema> {
+  JsonSchemaAdditionalPropertiesForSchemaMapper._();
+
+  static JsonSchemaAdditionalPropertiesForSchemaMapper? _instance;
+  static JsonSchemaAdditionalPropertiesForSchemaMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(
+        _instance = JsonSchemaAdditionalPropertiesForSchemaMapper._(),
+      );
+      JsonSchemaAdditionalPropertiesMapper.ensureInitialized().addSubMapper(
+        _instance!,
+      );
+      JsonSchemaMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaAdditionalPropertiesForSchema';
+
+  static JsonSchema _$schema(JsonSchemaAdditionalPropertiesForSchema v) =>
+      v.schema;
+  static const Field<JsonSchemaAdditionalPropertiesForSchema, JsonSchema>
+  _f$schema = Field('schema', _$schema);
+
+  @override
+  final MappableFields<JsonSchemaAdditionalPropertiesForSchema> fields = const {
+    #schema: _f$schema,
+  };
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue =
+      JsonSchemaAdditionalPropertiesForSchema.checkType;
+  @override
+  late final ClassMapperBase superMapper =
+      JsonSchemaAdditionalPropertiesMapper.ensureInitialized();
+
+  @override
+  final MappingHook superHook = const JsonSchemaAdditionalPropertiesHook();
+
+  static JsonSchemaAdditionalPropertiesForSchema _instantiate(
+    DecodingData data,
+  ) {
+    return JsonSchemaAdditionalPropertiesForSchema(data.dec(_f$schema));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaAdditionalPropertiesForSchema fromMap(
+    Map<String, dynamic> map,
+  ) {
+    return ensureInitialized()
+        .decodeMap<JsonSchemaAdditionalPropertiesForSchema>(map);
+  }
+
+  static JsonSchemaAdditionalPropertiesForSchema fromJson(String json) {
+    return ensureInitialized()
+        .decodeJson<JsonSchemaAdditionalPropertiesForSchema>(json);
+  }
+}
+
+mixin JsonSchemaAdditionalPropertiesForSchemaMappable {
+  String toJson() {
+    return JsonSchemaAdditionalPropertiesForSchemaMapper.ensureInitialized()
+        .encodeJson<JsonSchemaAdditionalPropertiesForSchema>(
+          this as JsonSchemaAdditionalPropertiesForSchema,
+        );
+  }
+
+  Map<String, dynamic> toMap() {
+    return JsonSchemaAdditionalPropertiesForSchemaMapper.ensureInitialized()
+        .encodeMap<JsonSchemaAdditionalPropertiesForSchema>(
+          this as JsonSchemaAdditionalPropertiesForSchema,
+        );
+  }
+
+  JsonSchemaAdditionalPropertiesForSchemaCopyWith<
+    JsonSchemaAdditionalPropertiesForSchema,
+    JsonSchemaAdditionalPropertiesForSchema,
+    JsonSchemaAdditionalPropertiesForSchema
+  >
+  get copyWith =>
+      _JsonSchemaAdditionalPropertiesForSchemaCopyWithImpl<
+        JsonSchemaAdditionalPropertiesForSchema,
+        JsonSchemaAdditionalPropertiesForSchema
+      >(this as JsonSchemaAdditionalPropertiesForSchema, $identity, $identity);
+  @override
+  String toString() {
+    return JsonSchemaAdditionalPropertiesForSchemaMapper.ensureInitialized()
+        .stringifyValue(this as JsonSchemaAdditionalPropertiesForSchema);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return JsonSchemaAdditionalPropertiesForSchemaMapper.ensureInitialized()
+        .equalsValue(this as JsonSchemaAdditionalPropertiesForSchema, other);
+  }
+
+  @override
+  int get hashCode {
+    return JsonSchemaAdditionalPropertiesForSchemaMapper.ensureInitialized()
+        .hashValue(this as JsonSchemaAdditionalPropertiesForSchema);
+  }
+}
+
+extension JsonSchemaAdditionalPropertiesForSchemaValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, JsonSchemaAdditionalPropertiesForSchema, $Out> {
+  JsonSchemaAdditionalPropertiesForSchemaCopyWith<
+    $R,
+    JsonSchemaAdditionalPropertiesForSchema,
+    $Out
+  >
+  get $asJsonSchemaAdditionalPropertiesForSchema => $base.as(
+    (v, t, t2) =>
+        _JsonSchemaAdditionalPropertiesForSchemaCopyWithImpl<$R, $Out>(
+          v,
+          t,
+          t2,
+        ),
+  );
+}
+
+abstract class JsonSchemaAdditionalPropertiesForSchemaCopyWith<
+  $R,
+  $In extends JsonSchemaAdditionalPropertiesForSchema,
+  $Out
+>
+    implements JsonSchemaAdditionalPropertiesCopyWith<$R, $In, $Out> {
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema> get schema;
+  @override
+  $R call({JsonSchema? schema});
+  JsonSchemaAdditionalPropertiesForSchemaCopyWith<$R2, $In, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _JsonSchemaAdditionalPropertiesForSchemaCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, JsonSchemaAdditionalPropertiesForSchema, $Out>
+    implements
+        JsonSchemaAdditionalPropertiesForSchemaCopyWith<
+          $R,
+          JsonSchemaAdditionalPropertiesForSchema,
+          $Out
+        > {
+  _JsonSchemaAdditionalPropertiesForSchemaCopyWithImpl(
+    super.value,
+    super.then,
+    super.then2,
+  );
+
+  @override
+  late final ClassMapperBase<JsonSchemaAdditionalPropertiesForSchema> $mapper =
+      JsonSchemaAdditionalPropertiesForSchemaMapper.ensureInitialized();
+  @override
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema> get schema =>
+      $value.schema.copyWith.$chain((v) => call(schema: v));
+  @override
+  $R call({JsonSchema? schema}) =>
+      $apply(FieldCopyWithData({if (schema != null) #schema: schema}));
+  @override
+  JsonSchemaAdditionalPropertiesForSchema $make(CopyWithData data) =>
+      JsonSchemaAdditionalPropertiesForSchema(
+        data.get(#schema, or: $value.schema),
+      );
+
+  @override
+  JsonSchemaAdditionalPropertiesForSchemaCopyWith<
+    $R2,
+    JsonSchemaAdditionalPropertiesForSchema,
+    $Out2
+  >
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _JsonSchemaAdditionalPropertiesForSchemaCopyWithImpl<$R2, $Out2>(
+        $value,
+        $cast,
+        t,
+      );
+}
+
+class JsonSchemaItemsArrayMapper
+    extends SubClassMapperBase<JsonSchemaItemsArray> {
+  JsonSchemaItemsArrayMapper._();
+
+  static JsonSchemaItemsArrayMapper? _instance;
+  static JsonSchemaItemsArrayMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = JsonSchemaItemsArrayMapper._());
+      JsonSchemaItemsMapper.ensureInitialized().addSubMapper(_instance!);
+      JsonSchemaMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaItemsArray';
+
+  static List<JsonSchema> _$schemas(JsonSchemaItemsArray v) => v.schemas;
+  static const Field<JsonSchemaItemsArray, List<JsonSchema>> _f$schemas = Field(
+    'schemas',
+    _$schemas,
+  );
+
+  @override
+  final MappableFields<JsonSchemaItemsArray> fields = const {
+    #schemas: _f$schemas,
+  };
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue = JsonSchemaItemsArray.checkType;
+  @override
+  late final ClassMapperBase superMapper =
+      JsonSchemaItemsMapper.ensureInitialized();
+
+  @override
+  final MappingHook superHook = const JsonSchemaItemsHook();
+
+  static JsonSchemaItemsArray _instantiate(DecodingData data) {
+    return JsonSchemaItemsArray(data.dec(_f$schemas));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaItemsArray fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<JsonSchemaItemsArray>(map);
+  }
+
+  static JsonSchemaItemsArray fromJson(String json) {
+    return ensureInitialized().decodeJson<JsonSchemaItemsArray>(json);
+  }
+}
+
+mixin JsonSchemaItemsArrayMappable {
+  String toJson() {
+    return JsonSchemaItemsArrayMapper.ensureInitialized()
+        .encodeJson<JsonSchemaItemsArray>(this as JsonSchemaItemsArray);
+  }
+
+  Map<String, dynamic> toMap() {
+    return JsonSchemaItemsArrayMapper.ensureInitialized()
+        .encodeMap<JsonSchemaItemsArray>(this as JsonSchemaItemsArray);
+  }
+
+  JsonSchemaItemsArrayCopyWith<
+    JsonSchemaItemsArray,
+    JsonSchemaItemsArray,
+    JsonSchemaItemsArray
+  >
+  get copyWith =>
+      _JsonSchemaItemsArrayCopyWithImpl<
+        JsonSchemaItemsArray,
+        JsonSchemaItemsArray
+      >(this as JsonSchemaItemsArray, $identity, $identity);
+  @override
+  String toString() {
+    return JsonSchemaItemsArrayMapper.ensureInitialized().stringifyValue(
+      this as JsonSchemaItemsArray,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return JsonSchemaItemsArrayMapper.ensureInitialized().equalsValue(
+      this as JsonSchemaItemsArray,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return JsonSchemaItemsArrayMapper.ensureInitialized().hashValue(
+      this as JsonSchemaItemsArray,
+    );
+  }
+}
+
+extension JsonSchemaItemsArrayValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, JsonSchemaItemsArray, $Out> {
+  JsonSchemaItemsArrayCopyWith<$R, JsonSchemaItemsArray, $Out>
+  get $asJsonSchemaItemsArray => $base.as(
+    (v, t, t2) => _JsonSchemaItemsArrayCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class JsonSchemaItemsArrayCopyWith<
+  $R,
+  $In extends JsonSchemaItemsArray,
+  $Out
+>
+    implements JsonSchemaItemsCopyWith<$R, $In, $Out> {
+  ListCopyWith<$R, JsonSchema, JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>>
+  get schemas;
+  @override
+  $R call({List<JsonSchema>? schemas});
+  JsonSchemaItemsArrayCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _JsonSchemaItemsArrayCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, JsonSchemaItemsArray, $Out>
+    implements JsonSchemaItemsArrayCopyWith<$R, JsonSchemaItemsArray, $Out> {
+  _JsonSchemaItemsArrayCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<JsonSchemaItemsArray> $mapper =
+      JsonSchemaItemsArrayMapper.ensureInitialized();
+  @override
+  ListCopyWith<$R, JsonSchema, JsonSchemaCopyWith<$R, JsonSchema, JsonSchema>>
+  get schemas => ListCopyWith(
+    $value.schemas,
+    (v, t) => v.copyWith.$chain(t),
+    (v) => call(schemas: v),
+  );
+  @override
+  $R call({List<JsonSchema>? schemas}) =>
+      $apply(FieldCopyWithData({if (schemas != null) #schemas: schemas}));
+  @override
+  JsonSchemaItemsArray $make(CopyWithData data) =>
+      JsonSchemaItemsArray(data.get(#schemas, or: $value.schemas));
+
+  @override
+  JsonSchemaItemsArrayCopyWith<$R2, JsonSchemaItemsArray, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _JsonSchemaItemsArrayCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class JsonSchemaItemsSingleMapper
+    extends SubClassMapperBase<JsonSchemaItemsSingle> {
+  JsonSchemaItemsSingleMapper._();
+
+  static JsonSchemaItemsSingleMapper? _instance;
+  static JsonSchemaItemsSingleMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = JsonSchemaItemsSingleMapper._());
+      JsonSchemaItemsMapper.ensureInitialized().addSubMapper(_instance!);
+      JsonSchemaMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaItemsSingle';
+
+  static JsonSchema _$schema(JsonSchemaItemsSingle v) => v.schema;
+  static const Field<JsonSchemaItemsSingle, JsonSchema> _f$schema = Field(
+    'schema',
+    _$schema,
+  );
+
+  @override
+  final MappableFields<JsonSchemaItemsSingle> fields = const {
+    #schema: _f$schema,
+  };
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue = JsonSchemaItemsSingle.checkType;
+  @override
+  late final ClassMapperBase superMapper =
+      JsonSchemaItemsMapper.ensureInitialized();
+
+  @override
+  final MappingHook superHook = const JsonSchemaItemsHook();
+
+  static JsonSchemaItemsSingle _instantiate(DecodingData data) {
+    return JsonSchemaItemsSingle(data.dec(_f$schema));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaItemsSingle fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<JsonSchemaItemsSingle>(map);
+  }
+
+  static JsonSchemaItemsSingle fromJson(String json) {
+    return ensureInitialized().decodeJson<JsonSchemaItemsSingle>(json);
+  }
+}
+
+mixin JsonSchemaItemsSingleMappable {
+  String toJson() {
+    return JsonSchemaItemsSingleMapper.ensureInitialized()
+        .encodeJson<JsonSchemaItemsSingle>(this as JsonSchemaItemsSingle);
+  }
+
+  Map<String, dynamic> toMap() {
+    return JsonSchemaItemsSingleMapper.ensureInitialized()
+        .encodeMap<JsonSchemaItemsSingle>(this as JsonSchemaItemsSingle);
+  }
+
+  JsonSchemaItemsSingleCopyWith<
+    JsonSchemaItemsSingle,
+    JsonSchemaItemsSingle,
+    JsonSchemaItemsSingle
+  >
+  get copyWith =>
+      _JsonSchemaItemsSingleCopyWithImpl<
+        JsonSchemaItemsSingle,
+        JsonSchemaItemsSingle
+      >(this as JsonSchemaItemsSingle, $identity, $identity);
+  @override
+  String toString() {
+    return JsonSchemaItemsSingleMapper.ensureInitialized().stringifyValue(
+      this as JsonSchemaItemsSingle,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return JsonSchemaItemsSingleMapper.ensureInitialized().equalsValue(
+      this as JsonSchemaItemsSingle,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return JsonSchemaItemsSingleMapper.ensureInitialized().hashValue(
+      this as JsonSchemaItemsSingle,
+    );
+  }
+}
+
+extension JsonSchemaItemsSingleValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, JsonSchemaItemsSingle, $Out> {
+  JsonSchemaItemsSingleCopyWith<$R, JsonSchemaItemsSingle, $Out>
+  get $asJsonSchemaItemsSingle => $base.as(
+    (v, t, t2) => _JsonSchemaItemsSingleCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class JsonSchemaItemsSingleCopyWith<
+  $R,
+  $In extends JsonSchemaItemsSingle,
+  $Out
+>
+    implements JsonSchemaItemsCopyWith<$R, $In, $Out> {
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema> get schema;
+  @override
+  $R call({JsonSchema? schema});
+  JsonSchemaItemsSingleCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _JsonSchemaItemsSingleCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, JsonSchemaItemsSingle, $Out>
+    implements JsonSchemaItemsSingleCopyWith<$R, JsonSchemaItemsSingle, $Out> {
+  _JsonSchemaItemsSingleCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<JsonSchemaItemsSingle> $mapper =
+      JsonSchemaItemsSingleMapper.ensureInitialized();
+  @override
+  JsonSchemaCopyWith<$R, JsonSchema, JsonSchema> get schema =>
+      $value.schema.copyWith.$chain((v) => call(schema: v));
+  @override
+  $R call({JsonSchema? schema}) =>
+      $apply(FieldCopyWithData({if (schema != null) #schema: schema}));
+  @override
+  JsonSchemaItemsSingle $make(CopyWithData data) =>
+      JsonSchemaItemsSingle(data.get(#schema, or: $value.schema));
+
+  @override
+  JsonSchemaItemsSingleCopyWith<$R2, JsonSchemaItemsSingle, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _JsonSchemaItemsSingleCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class JsonSchemaTypeArrayMapper
+    extends SubClassMapperBase<JsonSchemaTypeArray> {
+  JsonSchemaTypeArrayMapper._();
+
+  static JsonSchemaTypeArrayMapper? _instance;
+  static JsonSchemaTypeArrayMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = JsonSchemaTypeArrayMapper._());
+      JsonSchemaTypeMapper.ensureInitialized().addSubMapper(_instance!);
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaTypeArray';
+
+  static List<String> _$values(JsonSchemaTypeArray v) => v.values;
+  static const Field<JsonSchemaTypeArray, List<String>> _f$values = Field(
+    'values',
+    _$values,
+  );
+
+  @override
+  final MappableFields<JsonSchemaTypeArray> fields = const {#values: _f$values};
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue = JsonSchemaTypeArray.checkType;
+  @override
+  late final ClassMapperBase superMapper =
+      JsonSchemaTypeMapper.ensureInitialized();
+
+  @override
+  final MappingHook superHook = const JsonSchemaTypeHook();
+
+  static JsonSchemaTypeArray _instantiate(DecodingData data) {
+    return JsonSchemaTypeArray(data.dec(_f$values));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaTypeArray fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<JsonSchemaTypeArray>(map);
+  }
+
+  static JsonSchemaTypeArray fromJson(String json) {
+    return ensureInitialized().decodeJson<JsonSchemaTypeArray>(json);
+  }
+}
+
+mixin JsonSchemaTypeArrayMappable {
+  String toJson() {
+    return JsonSchemaTypeArrayMapper.ensureInitialized()
+        .encodeJson<JsonSchemaTypeArray>(this as JsonSchemaTypeArray);
+  }
+
+  Map<String, dynamic> toMap() {
+    return JsonSchemaTypeArrayMapper.ensureInitialized()
+        .encodeMap<JsonSchemaTypeArray>(this as JsonSchemaTypeArray);
+  }
+
+  JsonSchemaTypeArrayCopyWith<
+    JsonSchemaTypeArray,
+    JsonSchemaTypeArray,
+    JsonSchemaTypeArray
+  >
+  get copyWith =>
+      _JsonSchemaTypeArrayCopyWithImpl<
+        JsonSchemaTypeArray,
+        JsonSchemaTypeArray
+      >(this as JsonSchemaTypeArray, $identity, $identity);
+  @override
+  String toString() {
+    return JsonSchemaTypeArrayMapper.ensureInitialized().stringifyValue(
+      this as JsonSchemaTypeArray,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return JsonSchemaTypeArrayMapper.ensureInitialized().equalsValue(
+      this as JsonSchemaTypeArray,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return JsonSchemaTypeArrayMapper.ensureInitialized().hashValue(
+      this as JsonSchemaTypeArray,
+    );
+  }
+}
+
+extension JsonSchemaTypeArrayValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, JsonSchemaTypeArray, $Out> {
+  JsonSchemaTypeArrayCopyWith<$R, JsonSchemaTypeArray, $Out>
+  get $asJsonSchemaTypeArray => $base.as(
+    (v, t, t2) => _JsonSchemaTypeArrayCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class JsonSchemaTypeArrayCopyWith<
+  $R,
+  $In extends JsonSchemaTypeArray,
+  $Out
+>
+    implements JsonSchemaTypeCopyWith<$R, $In, $Out> {
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>> get values;
+  @override
+  $R call({List<String>? values});
+  JsonSchemaTypeArrayCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _JsonSchemaTypeArrayCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, JsonSchemaTypeArray, $Out>
+    implements JsonSchemaTypeArrayCopyWith<$R, JsonSchemaTypeArray, $Out> {
+  _JsonSchemaTypeArrayCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<JsonSchemaTypeArray> $mapper =
+      JsonSchemaTypeArrayMapper.ensureInitialized();
+  @override
+  ListCopyWith<$R, String, ObjectCopyWith<$R, String, String>> get values =>
+      ListCopyWith(
+        $value.values,
+        (v, t) => ObjectCopyWith(v, $identity, t),
+        (v) => call(values: v),
+      );
+  @override
+  $R call({List<String>? values}) =>
+      $apply(FieldCopyWithData({if (values != null) #values: values}));
+  @override
+  JsonSchemaTypeArray $make(CopyWithData data) =>
+      JsonSchemaTypeArray(data.get(#values, or: $value.values));
+
+  @override
+  JsonSchemaTypeArrayCopyWith<$R2, JsonSchemaTypeArray, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _JsonSchemaTypeArrayCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class JsonSchemaTypeSingleMapper
+    extends SubClassMapperBase<JsonSchemaTypeSingle> {
+  JsonSchemaTypeSingleMapper._();
+
+  static JsonSchemaTypeSingleMapper? _instance;
+  static JsonSchemaTypeSingleMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = JsonSchemaTypeSingleMapper._());
+      JsonSchemaTypeMapper.ensureInitialized().addSubMapper(_instance!);
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'JsonSchemaTypeSingle';
+
+  static String _$value(JsonSchemaTypeSingle v) => v.value;
+  static const Field<JsonSchemaTypeSingle, String> _f$value = Field(
+    'value',
+    _$value,
+  );
+
+  @override
+  final MappableFields<JsonSchemaTypeSingle> fields = const {#value: _f$value};
+
+  @override
+  final String discriminatorKey = 'type';
+  @override
+  final dynamic discriminatorValue = JsonSchemaTypeSingle.checkType;
+  @override
+  late final ClassMapperBase superMapper =
+      JsonSchemaTypeMapper.ensureInitialized();
+
+  @override
+  final MappingHook superHook = const JsonSchemaTypeHook();
+
+  static JsonSchemaTypeSingle _instantiate(DecodingData data) {
+    return JsonSchemaTypeSingle(data.dec(_f$value));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static JsonSchemaTypeSingle fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<JsonSchemaTypeSingle>(map);
+  }
+
+  static JsonSchemaTypeSingle fromJson(String json) {
+    return ensureInitialized().decodeJson<JsonSchemaTypeSingle>(json);
+  }
+}
+
+mixin JsonSchemaTypeSingleMappable {
+  String toJson() {
+    return JsonSchemaTypeSingleMapper.ensureInitialized()
+        .encodeJson<JsonSchemaTypeSingle>(this as JsonSchemaTypeSingle);
+  }
+
+  Map<String, dynamic> toMap() {
+    return JsonSchemaTypeSingleMapper.ensureInitialized()
+        .encodeMap<JsonSchemaTypeSingle>(this as JsonSchemaTypeSingle);
+  }
+
+  JsonSchemaTypeSingleCopyWith<
+    JsonSchemaTypeSingle,
+    JsonSchemaTypeSingle,
+    JsonSchemaTypeSingle
+  >
+  get copyWith =>
+      _JsonSchemaTypeSingleCopyWithImpl<
+        JsonSchemaTypeSingle,
+        JsonSchemaTypeSingle
+      >(this as JsonSchemaTypeSingle, $identity, $identity);
+  @override
+  String toString() {
+    return JsonSchemaTypeSingleMapper.ensureInitialized().stringifyValue(
+      this as JsonSchemaTypeSingle,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return JsonSchemaTypeSingleMapper.ensureInitialized().equalsValue(
+      this as JsonSchemaTypeSingle,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return JsonSchemaTypeSingleMapper.ensureInitialized().hashValue(
+      this as JsonSchemaTypeSingle,
+    );
+  }
+}
+
+extension JsonSchemaTypeSingleValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, JsonSchemaTypeSingle, $Out> {
+  JsonSchemaTypeSingleCopyWith<$R, JsonSchemaTypeSingle, $Out>
+  get $asJsonSchemaTypeSingle => $base.as(
+    (v, t, t2) => _JsonSchemaTypeSingleCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class JsonSchemaTypeSingleCopyWith<
+  $R,
+  $In extends JsonSchemaTypeSingle,
+  $Out
+>
+    implements JsonSchemaTypeCopyWith<$R, $In, $Out> {
+  @override
+  $R call({String? value});
+  JsonSchemaTypeSingleCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _JsonSchemaTypeSingleCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, JsonSchemaTypeSingle, $Out>
+    implements JsonSchemaTypeSingleCopyWith<$R, JsonSchemaTypeSingle, $Out> {
+  _JsonSchemaTypeSingleCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<JsonSchemaTypeSingle> $mapper =
+      JsonSchemaTypeSingleMapper.ensureInitialized();
+  @override
+  $R call({String? value}) =>
+      $apply(FieldCopyWithData({if (value != null) #value: value}));
+  @override
+  JsonSchemaTypeSingle $make(CopyWithData data) =>
+      JsonSchemaTypeSingle(data.get(#value, or: $value.value));
+
+  @override
+  JsonSchemaTypeSingleCopyWith<$R2, JsonSchemaTypeSingle, $Out2>
+  $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _JsonSchemaTypeSingleCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/packages/dart_mappable_schema/lib/src/json_schema_hook.dart
+++ b/packages/dart_mappable_schema/lib/src/json_schema_hook.dart
@@ -1,0 +1,86 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+import 'json_schema.dart';
+
+class JsonSchemaAdditionalPropertiesHook extends MappingHook {
+  const JsonSchemaAdditionalPropertiesHook();
+
+  @override
+  Object? afterDecode(Object? value) {
+    if (value is bool) {
+      return JsonSchemaAdditionalPropertiesForBool(value);
+    }
+    if (value is Map<String, dynamic>) {
+      return JsonSchemaAdditionalPropertiesForSchema(JsonSchema.fromMap(value));
+    }
+    return value;
+  }
+
+  @override
+  Object? beforeEncode(Object? value) {
+    if (value is JsonSchemaAdditionalPropertiesForBool) {
+      return value.value;
+    }
+    if (value is JsonSchemaAdditionalPropertiesForSchema) {
+      return value.schema.toMap();
+    }
+    return value;
+  }
+}
+
+class JsonSchemaItemsHook extends MappingHook {
+  const JsonSchemaItemsHook();
+
+  @override
+  Object? afterDecode(Object? value) {
+    if (value is Map<String, dynamic>) {
+      return JsonSchemaItemsSingle(JsonSchema.fromMap(value));
+    }
+    if (value is List) {
+      return JsonSchemaItemsArray(
+        value
+            .map((e) => JsonSchema.fromMap(e as Map<String, dynamic>))
+            .toList(),
+      );
+    }
+    return value;
+  }
+
+  @override
+  Object? beforeEncode(Object? value) {
+    if (value is JsonSchemaItemsSingle) {
+      return value.schema.toMap();
+    }
+    if (value is JsonSchemaItemsArray) {
+      return value.schemas.map((e) => e.toMap()).toList();
+    }
+    return value;
+  }
+}
+
+class JsonSchemaTypeHook extends MappingHook {
+  const JsonSchemaTypeHook();
+
+  @override
+  Object? afterDecode(Object? value) {
+    final v = value;
+    if (v is String) {
+      return JsonSchemaTypeSingle(v);
+    }
+    if (v is List) {
+      return JsonSchemaTypeArray(v.cast<String>());
+    }
+    return value;
+  }
+
+  @override
+  Object? beforeEncode(Object? value) {
+    if (value is JsonSchemaTypeSingle) {
+      return value.value; // encode as single string
+    }
+    if (value is JsonSchemaTypeArray) {
+      return value.values; // encode as list
+    }
+    return value;
+  }
+}

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -294,21 +294,5 @@ JsonSchema _schemaForType(
   } catch (_) {}
 
   // fallback any
-  return JsonSchema.anyOf([
-    JsonSchema.string(),
-    JsonSchema.number(),
-    JsonSchema.boolean(),
-    JsonSchema.object(
-      const {},
-      additionalProperties: JsonSchemaAdditionalProperties.bool(true),
-    ),
-    JsonSchema.array(
-      JsonSchema.anyOf([
-        JsonSchema.string(),
-        JsonSchema.number(),
-        JsonSchema.boolean(),
-      ]),
-    ),
-    JsonSchema.nullType(),
-  ]);
+  return JsonSchema();
 }

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -118,6 +118,7 @@ JsonSchema _buildClassSchema(
 
   // field properties
   for (final f in mapper.fields.values) {
+    if (f.mode == FieldMode.member) continue; // filter out member-only fields
     final overrideKey = '${mapper.id}.${f.key}';
     Type? valueType = fieldTypeOverrides[overrideKey];
     valueType ??= _resolveFieldValueType(f);

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -82,7 +82,7 @@ class _BuilderContext {
       var fieldSchema = _schemaForType(valueType, defValue: defVal);
 
       // optional -> allow null
-      if (includeNullForOptional && field.opt) {
+      if (includeNullForOptional && field.opt && defVal == null) {
         fieldSchema = JsonSchema.oneOf([fieldSchema, JsonSchema.nullType()]);
       }
 
@@ -224,7 +224,11 @@ class _BuilderContext {
       if (anyMapper is ClassMapperBase) {
         return _schemaForMapper<Object>(anyMapper);
       } else if (anyMapper is EnumMapper) {
-        return JsonSchema.string(enumValues: anyMapper.enums.keys.toList());
+        return JsonSchema.string(
+          enumValues: anyMapper.enums.keys.toList(),
+          defaultValue:
+              defValue != null ? anyMapper.encode(defValue as Enum) : null,
+        );
       }
     } catch (_) {}
 

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -103,15 +103,16 @@ class _BuilderContext {
         if (discValue is String && discKey is String) {
           final existing = properties[discKey];
           if (existing == null) {
-            properties[discKey] = JsonSchema.enumeration([discValue]);
+            properties[discKey] = JsonSchema.string(enumValues: [discValue]);
             if (!required.contains(discKey)) required.add(discKey);
           } else if (existing.enumValues == null ||
               !existing.enumValues!.contains(discValue)) {
-            properties[discKey] = JsonSchema.enumeration(
-              {
-                if (existing.enumValues != null) ...existing.enumValues!,
-                discValue,
-              }.toList(),
+            properties[discKey] = JsonSchema.string(
+              enumValues:
+                  {
+                    if (existing.enumValues != null) ...existing.enumValues!,
+                    discValue,
+                  }.toList(),
             );
           }
         }
@@ -146,7 +147,7 @@ class _BuilderContext {
               if (existing?.enumValues != null) ...existing!.enumValues!,
               ...discValues,
             }.toList();
-        properties[discKey] = JsonSchema.enumeration(mergedValues);
+        properties[discKey] = JsonSchema.string(enumValues: mergedValues);
         if (!required.contains(discKey)) required.add(discKey);
 
         final oneOfSchemas =

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -1,0 +1,263 @@
+import 'package:dart_mappable/dart_mappable.dart';
+import 'package:type_plus/type_plus.dart';
+
+import 'json_schema.dart';
+
+JsonSchema buildJsonSchemaFor<T extends Object>({
+  String? id,
+  String? schema = 'http://json-schema.org/draft-07/schema#',
+  MapperContainer? container,
+  Map<String, Type>? fieldTypeOverrides,
+  bool includeNullForOptional = true,
+}) {
+  container ??= MapperContainer.globals;
+  _registerFieldFactory();
+  final mapperBase = container.get<T>();
+  if (mapperBase is! ClassMapperBase<T>) {
+    throw ArgumentError(
+      'Type $T has no ClassMapperBase (missing @MappableClass?)',
+    );
+  }
+  final ctx = _BuilderContext(
+    container: container,
+    fieldTypeOverrides: fieldTypeOverrides ?? const {},
+    includeNullForOptional: includeNullForOptional,
+  );
+  final root = ctx._schemaForMapper<Object>(
+    mapperBase as ClassMapperBase<Object>,
+    isRoot: true,
+    id: id,
+    schema: schema,
+  );
+  return ctx.definitions.isEmpty
+      ? root
+      : root.copyWith(definitions: ctx.definitions);
+}
+
+// ---------------- Internal Implementation ----------------
+
+class _BuilderContext {
+  final MapperContainer container;
+  final Map<String, Type> fieldTypeOverrides;
+  final bool includeNullForOptional;
+
+  // collected definitions
+  final Map<String, JsonSchema> definitions = {};
+  final Set<Type> _visited = {};
+
+  _BuilderContext({
+    required this.container,
+    required this.fieldTypeOverrides,
+    required this.includeNullForOptional,
+  });
+
+  JsonSchema _schemaForMapper<T extends Object>(
+    ClassMapperBase<T> mapper, {
+    bool isRoot = false,
+    String? id,
+    String? schema,
+  }) {
+    final type = mapper.type;
+    if (!isRoot) {
+      // avoid rebuilding existing definition
+      if (_visited.contains(type)) {
+        return JsonSchema.refSchema('#/definitions/${mapper.id}');
+      }
+      _visited.add(type);
+    }
+
+    final properties = <String, JsonSchema>{};
+    final required = <String>[];
+
+    // fields
+    for (final field in mapper.fields.values) {
+      final key = field.key;
+      final overrideKey = '${mapper.id}.$key';
+      Type? valueType = fieldTypeOverrides[overrideKey];
+
+      // Field<M,V> second generic argument is value type
+      valueType ??= _extractFieldValueType(field);
+
+      final defVal = field.def;
+      var fieldSchema = _schemaForType(valueType, defValue: defVal);
+
+      // optional -> allow null
+      if (includeNullForOptional && field.opt) {
+        fieldSchema = JsonSchema.oneOf([fieldSchema, JsonSchema.nullType()]);
+      }
+
+      properties[key] = fieldSchema;
+      if (!field.opt) required.add(key);
+    }
+
+    final objectSchema = JsonSchema.object(
+      properties,
+      required: required.isEmpty ? null : required,
+    );
+    // If this mapper itself is a subclass, inject its discriminator fixed value so the variant schema is self-describing.
+    try {
+      if (mapper is SubClassMapperBase) {
+        final dynamic dyn = mapper;
+        final discKey = dyn.discriminatorKey;
+        final discValue = dyn.discriminatorValue;
+        if (discValue is String && discKey is String) {
+          final existing = properties[discKey];
+          if (existing == null) {
+            properties[discKey] = JsonSchema.enumeration([discValue]);
+            if (!required.contains(discKey)) required.add(discKey);
+          } else if (existing.enumValues == null ||
+              !existing.enumValues!.contains(discValue)) {
+            properties[discKey] = JsonSchema.enumeration(
+              {
+                if (existing.enumValues != null) ...existing.enumValues!,
+                discValue,
+              }.toList(),
+            );
+          }
+        }
+      }
+    } catch (_) {}
+    // ----- Polymorphism (subclasses) -----
+    // Detect subclasses (SubClassMapperBase) whose superMapper == current mapper.
+    try {
+      final subclasses = <SubClassMapperBase>[];
+      for (final m in container.getAll()) {
+        if (m is SubClassMapperBase) {
+          try {
+            final superMapper = m.superMapper as ClassMapperBase?;
+            if (superMapper?.id == mapper.id) subclasses.add(m);
+          } catch (_) {}
+        }
+      }
+
+      if (subclasses.isNotEmpty) {
+        final discKey = subclasses.first.discriminatorKey;
+        final discValues = <String>{};
+        for (final sub in subclasses) {
+          final dv = sub.discriminatorValue;
+          if (dv is String) discValues.add(dv);
+          // build subclass definition
+          _schemaForMapper<Object>(sub as ClassMapperBase<Object>);
+        }
+        // Add / merge discriminator property
+        final existing = properties[discKey];
+        final mergedValues = <Object?>{
+          if (existing?.enumValues != null) ...existing!.enumValues!,
+          ...discValues,
+        }.toList();
+        properties[discKey] = JsonSchema.enumeration(mergedValues);
+        if (!required.contains(discKey)) required.add(discKey);
+
+        final oneOfSchemas = subclasses
+            .map((s) => JsonSchema.refSchema('#/definitions/${s.id}'))
+            .toList();
+
+        final polyObject = objectSchema.copyWith(
+          oneOf: oneOfSchemas,
+          properties: properties,
+          required: required.isEmpty ? null : required,
+        );
+
+        if (!isRoot) {
+          definitions[mapper.id] = polyObject;
+          return JsonSchema.refSchema('#/definitions/${mapper.id}');
+        }
+        return polyObject.copyWith(title: mapper.id);
+      }
+    } catch (_) {}
+
+    if (!isRoot) {
+      definitions[mapper.id] = objectSchema;
+      return JsonSchema.refSchema('#/definitions/${mapper.id}');
+    }
+    return objectSchema.copyWith(title: mapper.id, schema: schema, id: id);
+  }
+
+  JsonSchema _schemaForType(Type? t, {dynamic defValue}) {
+    if (t == null) {
+      return JsonSchema.object(
+        const {},
+        additionalProperties: JsonSchemaAdditionalPropertiesForBool(true),
+      );
+    }
+
+    // Primitive
+    if (t == String) return JsonSchema.string(defaultValue: defValue);
+    if (t == int) return JsonSchema.integer(defaultValue: defValue);
+    if (t == double || t == num) {
+      return JsonSchema.number(defaultValue: defValue);
+    }
+    if (t == bool) return JsonSchema.boolean(defaultValue: defValue);
+    if (t == DateTime) return JsonSchema.string(format: 'date-time');
+
+    // collections
+    final base = t.base;
+    if (base == List || base == Set) {
+      final elemType = t.args.isNotEmpty ? t.args[0] : null;
+      final itemSchema = _schemaForType(elemType);
+      return JsonSchema.array(itemSchema);
+    }
+    if (base == Map) {
+      final keyType = t.args.isNotEmpty ? t.args[0] : null;
+      final valueType = t.args.length > 1 ? t.args[1] : null;
+      if (keyType != String) {
+        final entrySchema = JsonSchema.object(
+          {'key': JsonSchema.string(), 'value': _schemaForType(valueType)},
+          required: ['key', 'value'],
+        );
+        return JsonSchema.array(entrySchema);
+      }
+      final valueSchema = _schemaForType(valueType);
+      return JsonSchema.object(
+        const {},
+        additionalProperties: JsonSchemaAdditionalPropertiesForSchema(
+          valueSchema,
+        ),
+      );
+    }
+
+    // nested mappable
+    try {
+      final mapper = container.getAll().whereType<ClassMapperBase>().firstWhere(
+        (m) => m.type == t,
+      );
+      return _schemaForMapper<Object>(mapper);
+    } catch (_) {}
+
+    // fallback any
+    return JsonSchema.anyOf([
+      JsonSchema.string(),
+      JsonSchema.number(),
+      JsonSchema.boolean(),
+      JsonSchema.object(
+        const {},
+        additionalProperties: JsonSchemaAdditionalPropertiesForBool(true),
+      ),
+      JsonSchema.array(
+        JsonSchema.anyOf([
+          JsonSchema.string(),
+          JsonSchema.number(),
+          JsonSchema.boolean(),
+        ]),
+      ),
+      JsonSchema.nullType(),
+    ]);
+  }
+
+  Type? _extractFieldValueType(Field<Object, Object?> field) {
+    try {
+      final args = field.runtimeType.args; // Field<M,V>
+      if (args.length >= 2) return args[1];
+    } catch (_) {}
+    return null; // unresolved -> any fallback
+  }
+}
+
+Type captureType<T>() => typeOf<T>();
+
+bool _fieldFactoryRegistered = false;
+void _registerFieldFactory() {
+  if (_fieldFactoryRegistered) return;
+  _fieldFactoryRegistered = true;
+  TypePlus.addFactory(<M extends Object, V>(Function f) => f<Field<M, V>>());
+}

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -3,6 +3,10 @@ import 'package:type_plus/type_plus.dart';
 
 import 'json_schema.dart';
 
+bool _fieldFactoryRegistered = false;
+
+/// Build JSON Schema for type T. Scans referenced mappable classes first,
+/// then builds schemas in a second phase to avoid deep recursion.
 JsonSchema buildJsonSchemaFor<T extends Object>({
   String? id,
   String? schema = 'http://json-schema.org/draft-07/schema#',
@@ -12,263 +16,299 @@ JsonSchema buildJsonSchemaFor<T extends Object>({
 }) {
   container ??= MapperContainer.globals;
   _registerFieldFactory();
-  final mapperBase = container.get<T>();
-  if (mapperBase is! ClassMapperBase<T>) {
-    throw ArgumentError(
-      'Type $T has no ClassMapperBase (missing @MappableClass?)',
+
+  final rootMapper = container.get<T>() as ClassMapperBase<T>;
+
+  // Index mappers and map base id -> subclasses
+  final all = container.getAll();
+  final Map<Type, ClassMapperBase<Object>> typeToClass = {};
+  for (final m in all) {
+    if (m is ClassMapperBase) {
+      typeToClass[m.type] = m;
+    }
+  }
+  final Map<String, List<SubClassMapperBase>> baseIdToSubs = {};
+  for (final m in all) {
+    if (m is SubClassMapperBase) {
+      try {
+        final sup = m.superMapper as ClassMapperBase?;
+        if (sup != null) {
+          baseIdToSubs.putIfAbsent(sup.id, () => []).add(m);
+        }
+      } catch (_) {}
+    }
+  }
+
+  // Discovery: explicit stack DFS, track visited types
+  final Set<Type> visited = {};
+  final List<ClassMapperBase<Object>> stack = [rootMapper];
+  while (stack.isNotEmpty) {
+    final current = stack.removeLast();
+    final t = current.type;
+    if (!visited.add(t)) continue;
+
+    // subclasses
+    final subs = baseIdToSubs[current.id];
+    if (subs != null) {
+      stack.addAll(subs);
+    }
+
+    // field dependencies
+    for (final f in current.fields.values) {
+      final Type? fieldType = _resolveFieldValueType(f);
+      _enqueueType(fieldType, typeToClass, stack, visited);
+      // collection / generic inner types
+      try {
+        final base = fieldType?.base;
+        if (base == List || base == Set) {
+          final elem = fieldType!.args.isNotEmpty ? fieldType.args[0] : null;
+          _enqueueType(elem, typeToClass, stack, visited);
+        } else if (base == Map) {
+          final valueType =
+              fieldType!.args.length > 1 ? fieldType.args[1] : null;
+          _enqueueType(valueType, typeToClass, stack, visited);
+        }
+      } catch (_) {}
+    }
+  }
+
+  // Build: create schema for each visited type
+  final Map<String, JsonSchema> built = {};
+  for (final t in visited) {
+    final mapper = typeToClass[t]!;
+    built[mapper.id] = _buildClassSchema(
+      mapper,
+      isRoot: t == rootMapper.type,
+      fieldTypeOverrides: fieldTypeOverrides ?? const {},
+      includeNullForOptional: includeNullForOptional,
+      typeToClass: typeToClass,
+      baseIdToSubs: baseIdToSubs,
+      builtSchemas: built,
+      container: container,
     );
   }
-  final ctx = _BuilderContext(
-    container: container,
-    fieldTypeOverrides: fieldTypeOverrides ?? const {},
-    includeNullForOptional: includeNullForOptional,
-  );
-  final root = ctx._schemaForMapper<Object>(
-    mapperBase as ClassMapperBase<Object>,
-    isRoot: true,
-    id: id,
-    schema: schema,
-  );
-  return ctx.definitions.isEmpty
-      ? root
-      : root.copyWith(definitions: ctx.definitions);
+
+  final rootSchema = built[rootMapper.id]!;
+  final definitions = Map<String, JsonSchema>.from(built)
+    ..remove(rootMapper.id);
+  return definitions.isEmpty
+      ? rootSchema.copyWith(id: id, schema: schema, title: rootMapper.id)
+      : rootSchema.copyWith(
+        id: id,
+        schema: schema,
+        title: rootMapper.id,
+        definitions: definitions,
+      );
 }
 
-// ---------------- Internal Implementation ----------------
+// Build helpers
 
-class _BuilderContext {
-  final MapperContainer container;
-  final Map<String, Type> fieldTypeOverrides;
-  final bool includeNullForOptional;
+JsonSchema _buildClassSchema(
+  ClassMapperBase<Object> mapper, {
+  required bool isRoot,
+  required Map<String, Type> fieldTypeOverrides,
+  required bool includeNullForOptional,
+  required Map<Type, ClassMapperBase<Object>> typeToClass,
+  required Map<String, List<SubClassMapperBase>> baseIdToSubs,
+  required Map<String, JsonSchema> builtSchemas,
+  required MapperContainer container,
+}) {
+  final props = <String, JsonSchema>{};
+  final required = <String>[];
 
-  // collected definitions
-  final Map<String, JsonSchema> definitions = {};
-  final Set<Type> _visited = {};
-
-  _BuilderContext({
-    required this.container,
-    required this.fieldTypeOverrides,
-    required this.includeNullForOptional,
-  });
-
-  JsonSchema _schemaForMapper<T extends Object>(
-    ClassMapperBase<T> mapper, {
-    bool isRoot = false,
-    String? id,
-    String? schema,
-  }) {
-    final type = mapper.type;
-    if (!isRoot) {
-      // avoid rebuilding existing definition
-      if (_visited.contains(type)) {
-        return JsonSchema.refSchema('#/definitions/${mapper.id}');
-      }
-      _visited.add(type);
-    }
-
-    final properties = <String, JsonSchema>{};
-    final required = <String>[];
-
-    // fields
-    for (final field in mapper.fields.values) {
-      final key = field.key;
-      final overrideKey = '${mapper.id}.$key';
-      Type? valueType = fieldTypeOverrides[overrideKey];
-
-      // Field<M,V> second generic argument is value type
-      valueType ??= _extractFieldValueType(field);
-
-      final defVal = field.def;
-      var fieldSchema = _schemaForType(valueType, defValue: defVal);
-
-      // optional -> allow null
-      if (includeNullForOptional && field.opt && defVal == null) {
-        fieldSchema = JsonSchema.oneOf([fieldSchema, JsonSchema.nullType()]);
-      }
-
-      properties[key] = fieldSchema;
-      if (!field.opt) required.add(key);
-    }
-
-    final objectSchema = JsonSchema.object(
-      properties,
-      required: required.isEmpty ? null : required,
+  // field properties
+  for (final f in mapper.fields.values) {
+    final overrideKey = '${mapper.id}.${f.key}';
+    Type? valueType = fieldTypeOverrides[overrideKey];
+    valueType ??= _resolveFieldValueType(f);
+    final defVal = f.def;
+    var fieldSchema = _schemaForType(
+      valueType,
+      typeToClass: typeToClass,
+      fieldTypeOverrides: fieldTypeOverrides,
+      includeNullForOptional: includeNullForOptional,
+      defValue: defVal,
+      container: container,
     );
-    // If this mapper itself is a subclass, inject its discriminator fixed value so the variant schema is self-describing.
-    try {
-      if (mapper is SubClassMapperBase) {
-        final dynamic dyn = mapper;
-        final discKey = dyn.discriminatorKey;
-        final discValue = dyn.discriminatorValue;
-        if (discValue is String && discKey is String) {
-          final existing = properties[discKey];
-          if (existing == null) {
-            properties[discKey] = JsonSchema.string(enumValues: [discValue]);
-            if (!required.contains(discKey)) required.add(discKey);
-          } else if (existing.enumValues == null ||
-              !existing.enumValues!.contains(discValue)) {
-            properties[discKey] = JsonSchema.string(
-              enumValues: [
-                if (existing.enumValues != null)
-                  ...(existing.enumValues!.cast<String>()),
-                discValue,
-              ],
-            );
-          }
-        }
-      }
-    } catch (_) {}
-    // ----- Polymorphism (subclasses) -----
-    // Detect subclasses (SubClassMapperBase) whose superMapper == current mapper.
-    try {
-      final subclasses = <SubClassMapperBase>[];
-      for (final m in container.getAll()) {
-        if (m is SubClassMapperBase) {
-          try {
-            final superMapper = m.superMapper as ClassMapperBase?;
-            if (superMapper?.id == mapper.id) subclasses.add(m);
-          } catch (_) {}
-        }
-      }
-
-      if (subclasses.isNotEmpty) {
-        final discKey = subclasses.first.discriminatorKey;
-        final discValues = <String>{};
-        for (final sub in subclasses) {
-          final dv = sub.discriminatorValue;
-          if (dv is String) discValues.add(dv);
-          // build subclass definition
-          _schemaForMapper<Object>(sub as ClassMapperBase<Object>);
-        }
-        // Add / merge discriminator property
-        final existing = properties[discKey];
-        final mergedValues =
-            <Object?>{
-              if (existing?.enumValues != null) ...existing!.enumValues!,
-              ...discValues,
-            }.toList();
-        properties[discKey] = JsonSchema.string(enumValues: mergedValues);
-        if (!required.contains(discKey)) required.add(discKey);
-
-        final oneOfSchemas =
-            subclasses
-                .map((s) => JsonSchema.refSchema('#/definitions/${s.id}'))
-                .toList();
-
-        final polyObject = objectSchema.copyWith(
-          oneOf: oneOfSchemas,
-          properties: properties,
-          required: required.isEmpty ? null : required,
-        );
-
-        if (!isRoot) {
-          definitions[mapper.id] = polyObject;
-          return JsonSchema.refSchema('#/definitions/${mapper.id}');
-        }
-        return polyObject.copyWith(title: mapper.id);
-      }
-    } catch (_) {}
-
-    if (!isRoot) {
-      definitions[mapper.id] = objectSchema;
-      return JsonSchema.refSchema('#/definitions/${mapper.id}');
+    if (includeNullForOptional && f.opt && defVal == null) {
+      fieldSchema = JsonSchema.oneOf([fieldSchema, JsonSchema.nullType()]);
     }
-    return objectSchema.copyWith(title: mapper.id, schema: schema, id: id);
+    props[f.key] = fieldSchema;
+    if (!f.opt) required.add(f.key);
   }
 
-  JsonSchema _schemaForType(Type? t, {dynamic defValue}) {
-    if (t == null) {
-      return JsonSchema.object(
-        const {},
-        additionalProperties: JsonSchemaAdditionalPropertiesForBool(true),
-      );
-    }
-
-    // Primitive
-    if (t == String) {
-      return JsonSchema.string(defaultValue: defValue as String?);
-    }
-    if (t == int) return JsonSchema.integer(defaultValue: defValue as int?);
-    if (t == double || t == num) {
-      return JsonSchema.number(defaultValue: defValue as num?);
-    }
-    if (t == bool) return JsonSchema.boolean(defaultValue: defValue as bool?);
-    if (t == DateTime) return JsonSchema.string(format: 'date-time');
-
-    // collections
-    final base = t.base;
-    if (base == List || base == Set) {
-      final elemType = t.args.isNotEmpty ? t.args[0] : null;
-      final itemSchema = _schemaForType(elemType);
-      return JsonSchema.array(itemSchema);
-    }
-    if (base == Map) {
-      final keyType = t.args.isNotEmpty ? t.args[0] : null;
-      final valueType = t.args.length > 1 ? t.args[1] : null;
-      if (keyType != String) {
-        final entrySchema = JsonSchema.object(
-          {'key': JsonSchema.string(), 'value': _schemaForType(valueType)},
-          required: ['key', 'value'],
-        );
-        return JsonSchema.array(entrySchema);
+  // If self is a subclass add discriminator property
+  if (mapper is SubClassMapperBase) {
+    final discValue = mapper.discriminatorValue;
+    if (discValue is String) {
+      props[mapper.discriminatorKey] = JsonSchema.string(constValue: discValue);
+      if (!required.contains(mapper.discriminatorKey)) {
+        required.add(mapper.discriminatorKey);
       }
-      final valueSchema = _schemaForType(valueType);
-      return JsonSchema.object(
-        const {},
-        additionalProperties: JsonSchemaAdditionalPropertiesForSchema(
-          valueSchema,
-        ),
-      );
     }
-
-    // nested mappable
-    try {
-      final anyMapper = container.getAll().firstWhere((m) => m.type == t);
-      if (anyMapper is ClassMapperBase) {
-        return _schemaForMapper<Object>(anyMapper);
-      } else if (anyMapper is EnumMapper) {
-        return JsonSchema.string(
-          enumValues: anyMapper.enums.keys.toList(),
-          defaultValue:
-              defValue != null ? anyMapper.encode(defValue as Enum) : null,
-        );
-      }
-    } catch (_) {}
-
-    // fallback any
-    return JsonSchema.anyOf([
-      JsonSchema.string(),
-      JsonSchema.number(),
-      JsonSchema.boolean(),
-      JsonSchema.object(
-        const {},
-        additionalProperties: JsonSchemaAdditionalPropertiesForBool(true),
-      ),
-      JsonSchema.array(
-        JsonSchema.anyOf([
-          JsonSchema.string(),
-          JsonSchema.number(),
-          JsonSchema.boolean(),
-        ]),
-      ),
-      JsonSchema.nullType(),
-    ]);
   }
 
-  Type? _extractFieldValueType(Field<Object, Object?> field) {
-    try {
-      final args = field.runtimeType.args; // Field<M,V>
-      if (args.length >= 2) return args[1];
-    } catch (_) {}
-    return null; // unresolved -> any fallback
+  // Polymorphic base: add oneOf + discriminator enum
+  List<JsonSchema>? oneOf;
+  final subs = baseIdToSubs[mapper.id];
+  if (subs != null && subs.isNotEmpty) {
+    final discKey = subs.first.discriminatorKey;
+    final discValues =
+        <String>{
+          for (final s in subs)
+            if (s.discriminatorValue is String) s.discriminatorValue as String,
+        }.toList();
+    // merge existing
+    final existing = props[discKey];
+    final merged =
+        <String>{
+          if (existing?.enumValues != null)
+            ...existing!.enumValues!.whereType<String>(),
+          ...discValues,
+        }.toList();
+    props[discKey] = JsonSchema.string(enumValues: merged);
+    if (!required.contains(discKey)) required.add(discKey);
+    oneOf = [
+      for (final s in subs) JsonSchema.refSchema('#/definitions/${s.id}'),
+    ];
   }
+
+  return JsonSchema(
+    title: isRoot ? mapper.id : null,
+    type: JsonSchemaTypeSingle('object'),
+    properties: props,
+    required: required.isEmpty ? null : required,
+    oneOf: oneOf,
+    additionalProperties: JsonSchemaAdditionalPropertiesForBool(false),
+  );
 }
 
-Type captureType<T>() => typeOf<T>();
+void _enqueueType(
+  Type? t,
+  Map<Type, ClassMapperBase<Object>> typeToClass,
+  List<ClassMapperBase<Object>> stack,
+  Set<Type> visited,
+) {
+  if (t == null) return;
+  final ClassMapperBase<Object>? mapper = typeToClass[t];
+  if (mapper == null) return;
+  if (visited.contains(t)) return;
+  stack.add(mapper);
+}
 
-bool _fieldFactoryRegistered = false;
 void _registerFieldFactory() {
   if (_fieldFactoryRegistered) return;
   _fieldFactoryRegistered = true;
   TypePlus.addFactory(<M extends Object, V>(Function f) => f<Field<M, V>>());
+}
+
+Type? _resolveFieldValueType(Field<Object, Object?> field) {
+  try {
+    final args = field.runtimeType.args; // Field<M,V>
+    if (args.length >= 2) return args[1];
+  } catch (_) {}
+  return null;
+}
+
+JsonSchema _schemaForType(
+  Type? t, {
+  required Map<Type, ClassMapperBase<Object>> typeToClass,
+  required Map<String, Type> fieldTypeOverrides,
+  required bool includeNullForOptional,
+  required MapperContainer container,
+  dynamic defValue,
+}) {
+  if (t == null) {
+    return JsonSchema.object(
+      const {},
+      additionalProperties: JsonSchemaAdditionalPropertiesForBool(true),
+    );
+  }
+  if (t == String) return JsonSchema.string(defaultValue: defValue as String?);
+  if (t == int) return JsonSchema.integer(defaultValue: defValue as int?);
+  if (t == double || t == num) {
+    return JsonSchema.number(defaultValue: defValue as num?);
+  }
+  if (t == bool) return JsonSchema.boolean(defaultValue: defValue as bool?);
+  if (t == DateTime) return JsonSchema.string(format: 'date-time');
+
+  final base = t.base;
+  if (base == List || base == Set) {
+    final elem = t.args.isNotEmpty ? t.args[0] : null;
+    return JsonSchema.array(
+      _schemaForType(
+        elem,
+        typeToClass: typeToClass,
+        fieldTypeOverrides: fieldTypeOverrides,
+        includeNullForOptional: includeNullForOptional,
+        container: container,
+      ),
+    );
+  }
+  if (base == Map) {
+    final keyType = t.args.isNotEmpty ? t.args[0] : null;
+    final valueType = t.args.length > 1 ? t.args[1] : null;
+    if (keyType != String) {
+      final entrySchema = JsonSchema.object(
+        {
+          'key': JsonSchema.string(),
+          'value': _schemaForType(
+            valueType,
+            typeToClass: typeToClass,
+            fieldTypeOverrides: fieldTypeOverrides,
+            includeNullForOptional: includeNullForOptional,
+            container: container,
+          ),
+        },
+        required: ['key', 'value'],
+      );
+      return JsonSchema.array(entrySchema);
+    }
+    final vSchema = _schemaForType(
+      valueType,
+      typeToClass: typeToClass,
+      fieldTypeOverrides: fieldTypeOverrides,
+      includeNullForOptional: includeNullForOptional,
+      container: container,
+    );
+    return JsonSchema.object(
+      const {},
+      additionalProperties: JsonSchemaAdditionalPropertiesForSchema(vSchema),
+    );
+  }
+
+  // Mappable class -> $ref (definitions are built in the batch phase)
+  final classMapper = typeToClass[t];
+  if (classMapper != null) {
+    return JsonSchema.refSchema('#/definitions/${classMapper.id}');
+  }
+
+  // Enum -> string enum
+  try {
+    // Simple linear lookup (enum count is typically small)
+    // If needed, cache Type -> EnumMapper for performance
+    final enumMapper = container.get(t);
+    if (enumMapper is EnumMapper) {
+      return JsonSchema.string(enumValues: enumMapper.enums.keys.toList());
+    }
+  } catch (_) {}
+
+  // fallback any
+  return JsonSchema.anyOf([
+    JsonSchema.string(),
+    JsonSchema.number(),
+    JsonSchema.boolean(),
+    JsonSchema.object(
+      const {},
+      additionalProperties: JsonSchemaAdditionalProperties.bool(true),
+    ),
+    JsonSchema.array(
+      JsonSchema.anyOf([
+        JsonSchema.string(),
+        JsonSchema.number(),
+        JsonSchema.boolean(),
+      ]),
+    ),
+    JsonSchema.nullType(),
+  ]);
 }

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -108,11 +108,11 @@ class _BuilderContext {
           } else if (existing.enumValues == null ||
               !existing.enumValues!.contains(discValue)) {
             properties[discKey] = JsonSchema.string(
-              enumValues:
-                  {
-                    if (existing.enumValues != null) ...existing.enumValues!,
-                    discValue,
-                  }.toList(),
+              enumValues: [
+                if (existing.enumValues != null)
+                  ...(existing.enumValues!.cast<String>()),
+                discValue,
+              ],
             );
           }
         }
@@ -185,12 +185,14 @@ class _BuilderContext {
     }
 
     // Primitive
-    if (t == String) return JsonSchema.string(defaultValue: defValue);
-    if (t == int) return JsonSchema.integer(defaultValue: defValue);
-    if (t == double || t == num) {
-      return JsonSchema.number(defaultValue: defValue);
+    if (t == String) {
+      return JsonSchema.string(defaultValue: defValue as String?);
     }
-    if (t == bool) return JsonSchema.boolean(defaultValue: defValue);
+    if (t == int) return JsonSchema.integer(defaultValue: defValue as int?);
+    if (t == double || t == num) {
+      return JsonSchema.number(defaultValue: defValue as num?);
+    }
+    if (t == bool) return JsonSchema.boolean(defaultValue: defValue as bool?);
     if (t == DateTime) return JsonSchema.string(format: 'date-time');
 
     // collections

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -141,16 +141,18 @@ class _BuilderContext {
         }
         // Add / merge discriminator property
         final existing = properties[discKey];
-        final mergedValues = <Object?>{
-          if (existing?.enumValues != null) ...existing!.enumValues!,
-          ...discValues,
-        }.toList();
+        final mergedValues =
+            <Object?>{
+              if (existing?.enumValues != null) ...existing!.enumValues!,
+              ...discValues,
+            }.toList();
         properties[discKey] = JsonSchema.enumeration(mergedValues);
         if (!required.contains(discKey)) required.add(discKey);
 
-        final oneOfSchemas = subclasses
-            .map((s) => JsonSchema.refSchema('#/definitions/${s.id}'))
-            .toList();
+        final oneOfSchemas =
+            subclasses
+                .map((s) => JsonSchema.refSchema('#/definitions/${s.id}'))
+                .toList();
 
         final polyObject = objectSchema.copyWith(
           oneOf: oneOfSchemas,
@@ -218,10 +220,12 @@ class _BuilderContext {
 
     // nested mappable
     try {
-      final mapper = container.getAll().whereType<ClassMapperBase>().firstWhere(
-        (m) => m.type == t,
-      );
-      return _schemaForMapper<Object>(mapper);
+      final anyMapper = container.getAll().firstWhere((m) => m.type == t);
+      if (anyMapper is ClassMapperBase) {
+        return _schemaForMapper<Object>(anyMapper);
+      } else if (anyMapper is EnumMapper) {
+        return JsonSchema.string(enumValues: anyMapper.enums.keys.toList());
+      }
     } catch (_) {}
 
     // fallback any

--- a/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
+++ b/packages/dart_mappable_schema/lib/src/mapper_to_schema.dart
@@ -179,7 +179,9 @@ JsonSchema _buildClassSchema(
     properties: props,
     required: required.isEmpty ? null : required,
     oneOf: oneOf,
-    additionalProperties: JsonSchemaAdditionalPropertiesForBool(false),
+    additionalProperties: JsonSchemaAdditionalProperties.bool(
+      subs == null ? false : true,
+    ),
   );
 }
 
@@ -219,10 +221,7 @@ JsonSchema _schemaForType(
   dynamic defValue,
 }) {
   if (t == null) {
-    return JsonSchema.object(
-      const {},
-      additionalProperties: JsonSchemaAdditionalPropertiesForBool(true),
-    );
+    return JsonSchema.nullType();
   }
   if (t == String) return JsonSchema.string(defaultValue: defValue as String?);
   if (t == int) return JsonSchema.integer(defaultValue: defValue as int?);

--- a/packages/dart_mappable_schema/pubspec.yaml
+++ b/packages/dart_mappable_schema/pubspec.yaml
@@ -17,12 +17,12 @@ topics:
   - dart
 
 dependencies:
-  dart_mappable: ^4.6.0
+  dart_mappable: ^4.6.1
   meta: ^1.8.0
   type_plus: ^2.1.1
 
 dev_dependencies:
-  build_runner: ^2.4.14
-  dart_mappable_builder: ^4.6.0
-  lints: ^5.0.0
+  build_runner: ^2.8.0
+  dart_mappable_builder: ^4.6.1
+  lints: ^6.0.0
   test: ^1.25.10

--- a/packages/dart_mappable_schema/pubspec.yaml
+++ b/packages/dart_mappable_schema/pubspec.yaml
@@ -1,0 +1,28 @@
+name: dart_mappable_schema
+description: Generate JSON Schema from dart_mappable models and utilities to work with those schemas.
+version: 0.1.0
+repository: https://github.com/schultek/dart_mappable
+issue_tracker: https://github.com/schultek/dart_mappable/issues
+documentation: https://pub.dev/documentation/dart_mappable/latest/topics/Introduction-topic.html
+funding:
+  - https://github.com/sponsors/schultek
+
+environment:
+  sdk: '>=3.7.0 <4.0.0'
+
+topics:
+  - json
+  - json-schema
+  - codegen
+  - dart
+
+dependencies:
+  dart_mappable: ^4.6.0
+  meta: ^1.8.0
+  type_plus: ^2.1.1
+
+dev_dependencies:
+  build_runner: ^2.4.14
+  dart_mappable_builder: ^4.6.0
+  lints: ^5.0.0
+  test: ^1.25.10


### PR DESCRIPTION
This PR introduces the ability to generate JSON Schema (Draft 07) definitions from dart_mappable annotated model classes. To keep the core lightweight and because schema generation is an optional concern, the feature is implemented in a new subpackage.

Some downstream tooling (validation, form generation, API contracts, documentation) benefits from having machine‑readable JSON Schemas derived from existing model annotations. Rather than requiring manual schema maintenance, this automates schema emission directly from dart_mappable metadata.

Key Changes

1. New subpackage: Adds a dedicated subpackage focused on JSON Schema generation so the core package remains minimal.
1. Type extraction: Uses type_plus to resolve and extract concrete types from Field metadata.
1. Polymorphism support: Handles dart_mappable polymorphic features (e.g. union / subclass mappings) when building schemas (where applicable).
1. Default values & nullability: Emits oneOf constructs to represent nullable fields with defaults.
1. Collection handling: Supports arrays (List<T>) and nested object references.

### Example
Dart model:
```dart
@MappableClass()
class User with UserMappable {
  final String name;
  final int age;
  final List<String> tags;

  User({required this.name, this.age = 10, required this.tags});
}
``` 
Generated JSON Schema (Draft 07):
```dart
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "User",
  "type": "object",
  "properties": {
    "name": { "type": "string" },
    "age": {
      "oneOf": [
        { "type": "integer", "default": 10 },
        { "type": "null" }
      ]
    },
    "tags": {
      "type": "array",
      "items": { "type": "string" }
    }
  },
  "required": ["name", "tags"]
}
``` 