### PR TITLE
Enhance field serialization control with @MappableField options

### DIFF
--- a/examples/fic_mappable/lib/main.mapper.dart
+++ b/examples/fic_mappable/lib/main.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -22,7 +23,13 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static IList<B> _$list(A v) => v.list;
-  static const Field<A, IList<B>> _f$list = Field('list', _$list);
+  static const Field<A, IList<B>> _f$list = Field(
+    'list',
+    _$list,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#list: _f$list};
@@ -53,7 +60,7 @@ mixin AMappable {
   }
 
   ACopyWith<A, A, A> get copyWith =>
-      _ACopyWithImpl(this as A, $identity, $identity);
+      _ACopyWithImpl<A, A>(this as A, $identity, $identity);
   @override
   String toString() {
     return AMapper.ensureInitialized().stringifyValue(this as A);
@@ -72,7 +79,7 @@ mixin AMappable {
 
 extension AValueCopy<$R, $Out> on ObjectCopyWith<$R, A, $Out> {
   ACopyWith<$R, A, $Out> get $asA =>
-      $base.as((v, t, t2) => _ACopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _ACopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class ACopyWith<$R, $In extends A, $Out>
@@ -95,7 +102,7 @@ class _ACopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, A, $Out>
 
   @override
   ACopyWith<$R2, A, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _ACopyWithImpl($value, $cast, t);
+      _ACopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
 class BMapper extends ClassMapperBase<B> {
@@ -113,7 +120,13 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static String _$str(B v) => v.str;
-  static const Field<B, String> _f$str = Field('str', _$str);
+  static const Field<B, String> _f$str = Field(
+    'str',
+    _$str,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#str: _f$str};
@@ -144,7 +157,7 @@ mixin BMappable {
   }
 
   BCopyWith<B, B, B> get copyWith =>
-      _BCopyWithImpl(this as B, $identity, $identity);
+      _BCopyWithImpl<B, B>(this as B, $identity, $identity);
   @override
   String toString() {
     return BMapper.ensureInitialized().stringifyValue(this as B);
@@ -163,7 +176,7 @@ mixin BMappable {
 
 extension BValueCopy<$R, $Out> on ObjectCopyWith<$R, B, $Out> {
   BCopyWith<$R, B, $Out> get $asB =>
-      $base.as((v, t, t2) => _BCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _BCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class BCopyWith<$R, $In extends B, $Out>
@@ -186,5 +199,6 @@ class _BCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, B, $Out>
 
   @override
   BCopyWith<$R2, B, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _BCopyWithImpl($value, $cast, t);
+      _BCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/examples/freezed_mappable/lib/main.mapper.dart
+++ b/examples/freezed_mappable/lib/main.mapper.dart
@@ -83,26 +83,13 @@ class DataMapper extends SubClassMapperBase<Data> {
     'value',
     _$value,
     key: r'mykey',
-  );
-  static $DataCopyWith<Data> _$copyWith(Data v) => v.copyWith;
-  static const Field<Data, $DataCopyWith<Data>> _f$copyWith = Field(
-    'copyWith',
-    _$copyWith,
-    mode: FieldMode.member,
-  );
-  static int _$hashCode(Data v) => v.hashCode;
-  static const Field<Data, int> _f$hashCode = Field(
-    'hashCode',
-    _$hashCode,
-    mode: FieldMode.member,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
-  final MappableFields<Data> fields = const {
-    #value: _f$value,
-    #copyWith: _f$copyWith,
-    #hashCode: _f$hashCode,
-  };
+  final MappableFields<Data> fields = const {#value: _f$value};
 
   @override
   final String discriminatorKey = 'type';
@@ -153,26 +140,16 @@ class LoadingMapper extends SubClassMapperBase<Loading> {
   final String id = 'Loading';
 
   static int _$value(Loading v) => v.value;
-  static const Field<Loading, int> _f$value = Field('value', _$value);
-  static $LoadingCopyWith<Loading> _$copyWith(Loading v) => v.copyWith;
-  static const Field<Loading, $LoadingCopyWith<Loading>> _f$copyWith = Field(
-    'copyWith',
-    _$copyWith,
-    mode: FieldMode.member,
-  );
-  static int _$hashCode(Loading v) => v.hashCode;
-  static const Field<Loading, int> _f$hashCode = Field(
-    'hashCode',
-    _$hashCode,
-    mode: FieldMode.member,
+  static const Field<Loading, int> _f$value = Field(
+    'value',
+    _$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
-  final MappableFields<Loading> fields = const {
-    #value: _f$value,
-    #copyWith: _f$copyWith,
-    #hashCode: _f$hashCode,
-  };
+  final MappableFields<Loading> fields = const {#value: _f$value};
 
   @override
   final String discriminatorKey = 'type';
@@ -223,30 +200,27 @@ class ErrorDetailsMapper extends SubClassMapperBase<ErrorDetails> {
   final String id = 'ErrorDetails';
 
   static int _$value(ErrorDetails v) => v.value;
-  static const Field<ErrorDetails, int> _f$value = Field('value', _$value);
+  static const Field<ErrorDetails, int> _f$value = Field(
+    'value',
+    _$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String? _$message(ErrorDetails v) => v.message;
   static const Field<ErrorDetails, String> _f$message = Field(
     'message',
     _$message,
     opt: true,
-  );
-  static $ErrorDetailsCopyWith<ErrorDetails> _$copyWith(ErrorDetails v) =>
-      v.copyWith;
-  static const Field<ErrorDetails, $ErrorDetailsCopyWith<ErrorDetails>>
-  _f$copyWith = Field('copyWith', _$copyWith, mode: FieldMode.member);
-  static int _$hashCode(ErrorDetails v) => v.hashCode;
-  static const Field<ErrorDetails, int> _f$hashCode = Field(
-    'hashCode',
-    _$hashCode,
-    mode: FieldMode.member,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
   final MappableFields<ErrorDetails> fields = const {
     #value: _f$value,
     #message: _f$message,
-    #copyWith: _f$copyWith,
-    #hashCode: _f$hashCode,
   };
 
   @override

--- a/examples/polymorph_copywith/lib/models/animal.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/animal.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -23,7 +24,13 @@ class AnimalMapper extends ClassMapperBase<Animal> {
   final String id = 'Animal';
 
   static String _$name(Animal v) => v.name;
-  static const Field<Animal, String> _f$name = Field('name', _$name);
+  static const Field<Animal, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Animal> fields = const {#name: _f$name};
@@ -59,3 +66,4 @@ abstract class AnimalCopyWith<$R, $In extends Animal, $Out>
   $R call({String? name});
   AnimalCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
+

--- a/examples/polymorph_copywith/lib/models/cat.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/cat.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -25,11 +26,11 @@ class CatTypeMapper extends EnumMapper<CatType> {
   @override
   CatType decode(dynamic value) {
     switch (value) {
-      case 'black':
+      case r'black':
         return CatType.black;
-      case 'siamese':
+      case r'siamese':
         return CatType.siamese;
-      case 'tiger':
+      case r'tiger':
         return CatType.tiger;
       default:
         throw MapperException.unknownEnumValue(value);
@@ -40,11 +41,11 @@ class CatTypeMapper extends EnumMapper<CatType> {
   dynamic encode(CatType self) {
     switch (self) {
       case CatType.black:
-        return 'black';
+        return r'black';
       case CatType.siamese:
-        return 'siamese';
+        return r'siamese';
       case CatType.tiger:
-        return 'tiger';
+        return r'tiger';
     }
   }
 }
@@ -73,11 +74,29 @@ class CatMapper extends SubClassMapperBase<Cat> {
   final String id = 'Cat';
 
   static String _$name(Cat v) => v.name;
-  static const Field<Cat, String> _f$name = Field('name', _$name);
+  static const Field<Cat, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static CatType _$breed(Cat v) => v.breed;
-  static const Field<Cat, CatType> _f$breed = Field('breed', _$breed);
+  static const Field<Cat, CatType> _f$breed = Field(
+    'breed',
+    _$breed,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$color(Cat v) => v.color;
-  static const Field<Cat, String> _f$color = Field('color', _$color);
+  static const Field<Cat, String> _f$color = Field(
+    'color',
+    _$color,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Cat> fields = const {
@@ -119,7 +138,7 @@ mixin CatMappable {
   }
 
   CatCopyWith<Cat, Cat, Cat> get copyWith =>
-      _CatCopyWithImpl(this as Cat, $identity, $identity);
+      _CatCopyWithImpl<Cat, Cat>(this as Cat, $identity, $identity);
   @override
   String toString() {
     return CatMapper.ensureInitialized().stringifyValue(this as Cat);
@@ -138,7 +157,7 @@ mixin CatMappable {
 
 extension CatValueCopy<$R, $Out> on ObjectCopyWith<$R, Cat, $Out> {
   CatCopyWith<$R, Cat, $Out> get $asCat =>
-      $base.as((v, t, t2) => _CatCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _CatCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class CatCopyWith<$R, $In extends Cat, $Out>
@@ -171,5 +190,6 @@ class _CatCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Cat, $Out>
 
   @override
   CatCopyWith<$R2, Cat, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _CatCopyWithImpl($value, $cast, t);
+      _CatCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/examples/polymorph_copywith/lib/models/dog.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/dog.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -23,11 +24,29 @@ class DogMapper extends SubClassMapperBase<Dog> {
   final String id = 'Dog';
 
   static String _$name(Dog v) => v.name;
-  static const Field<Dog, String> _f$name = Field('name', _$name);
+  static const Field<Dog, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$age(Dog v) => v.age;
-  static const Field<Dog, int> _f$age = Field('age', _$age);
+  static const Field<Dog, int> _f$age = Field(
+    'age',
+    _$age,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Person _$owner(Dog v) => v.owner;
-  static const Field<Dog, Person> _f$owner = Field('owner', _$owner);
+  static const Field<Dog, Person> _f$owner = Field(
+    'owner',
+    _$owner,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Dog> fields = const {
@@ -69,7 +88,7 @@ mixin DogMappable {
   }
 
   DogCopyWith<Dog, Dog, Dog> get copyWith =>
-      _DogCopyWithImpl(this as Dog, $identity, $identity);
+      _DogCopyWithImpl<Dog, Dog>(this as Dog, $identity, $identity);
   @override
   String toString() {
     return DogMapper.ensureInitialized().stringifyValue(this as Dog);
@@ -88,7 +107,7 @@ mixin DogMappable {
 
 extension DogValueCopy<$R, $Out> on ObjectCopyWith<$R, Dog, $Out> {
   DogCopyWith<$R, Dog, $Out> get $asDog =>
-      $base.as((v, t, t2) => _DogCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _DogCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class DogCopyWith<$R, $In extends Dog, $Out>
@@ -125,5 +144,6 @@ class _DogCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Dog, $Out>
 
   @override
   DogCopyWith<$R2, Dog, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _DogCopyWithImpl($value, $cast, t);
+      _DogCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/examples/polymorph_copywith/lib/models/person.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/person.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -21,7 +22,13 @@ class PersonMapper extends ClassMapperBase<Person> {
   final String id = 'Person';
 
   static String _$name(Person v) => v.name;
-  static const Field<Person, String> _f$name = Field('name', _$name);
+  static const Field<Person, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Person> fields = const {#name: _f$name};
@@ -52,7 +59,7 @@ mixin PersonMappable {
   }
 
   PersonCopyWith<Person, Person, Person> get copyWith =>
-      _PersonCopyWithImpl(this as Person, $identity, $identity);
+      _PersonCopyWithImpl<Person, Person>(this as Person, $identity, $identity);
   @override
   String toString() {
     return PersonMapper.ensureInitialized().stringifyValue(this as Person);
@@ -71,7 +78,7 @@ mixin PersonMappable {
 
 extension PersonValueCopy<$R, $Out> on ObjectCopyWith<$R, Person, $Out> {
   PersonCopyWith<$R, Person, $Out> get $asPerson =>
-      $base.as((v, t, t2) => _PersonCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _PersonCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class PersonCopyWith<$R, $In extends Person, $Out>
@@ -94,5 +101,6 @@ class _PersonCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Person, $Out>
 
   @override
   PersonCopyWith<$R2, Person, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _PersonCopyWithImpl($value, $cast, t);
+      _PersonCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/examples/polymorph_copywith/lib/models/zoo.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/zoo.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -21,7 +22,8 @@ class ZooMapper extends ClassMapperBase<Zoo> {
   @override
   final String id = 'Zoo';
   @override
-  Function get typeFactory => <T extends Animal>(f) => f<Zoo<T>>();
+  Function get typeFactory =>
+      <T extends Animal>(f) => f<Zoo<T>>();
 
   static List<Animal> _$animals(Zoo v) => v.animals;
   static dynamic _arg$animals<T extends Animal>(f) => f<List<T>>();
@@ -29,6 +31,9 @@ class ZooMapper extends ClassMapperBase<Zoo> {
     'animals',
     _$animals,
     arg: _arg$animals,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -60,7 +65,7 @@ mixin ZooMappable<T extends Animal> {
   }
 
   ZooCopyWith<Zoo<T>, Zoo<T>, Zoo<T>, T> get copyWith =>
-      _ZooCopyWithImpl(this as Zoo<T>, $identity, $identity);
+      _ZooCopyWithImpl<Zoo<T>, Zoo<T>, T>(this as Zoo<T>, $identity, $identity);
   @override
   String toString() {
     return ZooMapper.ensureInitialized().stringifyValue(this as Zoo<T>);
@@ -80,7 +85,7 @@ mixin ZooMappable<T extends Animal> {
 extension ZooValueCopy<$R, $Out, T extends Animal>
     on ObjectCopyWith<$R, Zoo<T>, $Out> {
   ZooCopyWith<$R, Zoo<T>, $Out, T> get $asZoo =>
-      $base.as((v, t, t2) => _ZooCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _ZooCopyWithImpl<$R, $Out, T>(v, t, t2));
 }
 
 abstract class ZooCopyWith<$R, $In extends Zoo<T>, $Out, T extends Animal>
@@ -112,5 +117,6 @@ class _ZooCopyWithImpl<$R, $Out, T extends Animal>
 
   @override
   ZooCopyWith<$R2, Zoo<T>, $Out2, T> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _ZooCopyWithImpl($value, $cast, t);
+      _ZooCopyWithImpl<$R2, $Out2, T>($value, $cast, t);
 }
+

--- a/packages/dart_mappable/README.md
+++ b/packages/dart_mappable/README.md
@@ -32,15 +32,15 @@
 
 ---
 
-`dart_mappable` covers all basic features *(from/to json, == override, hashCode, toString(), copyWith)*
-while adding new or improved support for advanced use-cases including **generics, inheritance and 
+`dart_mappable` covers all basic features _(from/to json, == override, hashCode, toString(), copyWith)_
+while adding new or improved support for advanced use-cases including **generics, inheritance and
 polymorphism, customization** and more.
 
 - 🎁 **Everything included**: Serialization, Equality, ToString, CopyWith and more.
 - 🚀 **Excels at complexity**: It handles generics, polymorphism and multi-inheritance with ease.
-- 🎛️ **Highly flexible**: Customize the serialization, add custom types or integrate with other packages.
+- 🎛️ **Highly flexible**: Customize the serialization, add custom types, control field inclusion, or integrate with other packages.
 - 🔥 **No compromises**: Its promise is that it just works, no matter what classes you throw at it.  
-  *(If you find an unsupported case, you get a cookie 🍪. And please add an issue on [github](https://github.com/schultek/dart_mappable).)*
+  _(If you find an unsupported case, you get a cookie 🍪. And please add an issue on [github](https://github.com/schultek/dart_mappable).)_
 
 ## Quick Start
 
@@ -77,11 +77,11 @@ To use a class you must:
 - annotate the class with `@MappableClass()` and
 - apply a mixin with the name of the class plus `Mappable`.
 
-***Tip**: Don't worry if the mixin don't exist at first, just run code-generation once and it will be created.
-The builder will also warn you if you define your class without the proper mixin.*
+**\*Tip**: Don't worry if the mixin don't exist at first, just run code-generation once and it will be created.
+The builder will also warn you if you define your class without the proper mixin.\*
 
-***Note**: For generic classes (e.g. `MyClass<T>`) make sure to also provide all type parameters
-to the mixin (`... with MyClassMappable<T>`).*
+**\*Note**: For generic classes (e.g. `MyClass<T>`) make sure to also provide all type parameters
+to the mixin (`... with MyClassMappable<T>`).\*
 
 ---
 
@@ -91,8 +91,8 @@ In order to generate the serialization code, run the following command:
 dart run build_runner build
 ```
 
-***Tip**: You'll need to re-run code generation each time you are making changes to your annotated classes.
-During development, you can use `watch` to automatically watch your changes: `dart run build_runner watch`.*
+**\*Tip**: You'll need to re-run code generation each time you are making changes to your annotated classes.
+During development, you can use `watch` to automatically watch your changes: `dart run build_runner watch`.\*
 
 This will generate a `<filename>.mapper.dart` file for each of your files containing annotated classes.
 
@@ -110,27 +110,27 @@ using this package:
 void main() {
   // Decode a [Map] using the [MyClassMapper] class:
   MyClass myClass = MyClassMapper.fromMap({'myValue': 123});
-  
+
   // Or decode directly from json:
   MyClass myClass2 = MyClassMapper.fromJson('{"myValue": 123}');
-  
+
   // Encode an instance of your class using the methods provided by the mixin:
   Map<String, dynamic> map = myClass.toMap();
   String json = myClass.toJson();
-  
+
   // There are also implementations generated for [operator ==], [hashCode] and [toString]:
   bool thisIsTrue = (myClass == myClass2);
   print(myClass);
-  
+
   // Last you can use [copyWith] to create a copy of an object:
   MyClass myClass3 = myClass.copyWith(myValue: 0);
 }
 ```
 
-***Beware**: The `.toJson()` method returns a `String`. If you are migrating from `json_serializable`, you might
-be used to this returning a `Map<String, dynamic>` instead. Make sure to properly adapt your code to this change, 
-as not doing so might lead to unexpected behavior. Find more about the recommended migration path 
-[here](https://pub.dev/documentation/dart_mappable/latest/topics/Migration%20and%20Compatibility-topic.html)*.
+**\*Beware**: The `.toJson()` method returns a `String`. If you are migrating from `json_serializable`, you might
+be used to this returning a `Map<String, dynamic>` instead. Make sure to properly adapt your code to this change,
+as not doing so might lead to unexpected behavior. Find more about the recommended migration path
+[here](https://pub.dev/documentation/dart_mappable/latest/topics/Migration%20and%20Compatibility-topic.html)\*.
 
 ## Overview
 
@@ -145,9 +145,9 @@ class MyClass with MyClassMappable { ... }
 enum MyEnum { ... }
 ```
 
-***Tip**: Check out the documentation about
+**\*Tip**: Check out the documentation about
 [Models](https://pub.dev/documentation/dart_mappable/latest/topics/Models-topic.html) and
-[Enums](https://pub.dev/documentation/dart_mappable/latest/topics/Enums-topic.html).*
+[Enums](https://pub.dev/documentation/dart_mappable/latest/topics/Enums-topic.html).\*
 
 For deserialization, `dart_mappable` will use the first available constructor of a class, but you
 can use a specific constructor using the `@MappableConstructor()` annotation.
@@ -163,24 +163,42 @@ class MyClass with MyClassMappable {
 ```
 
 You can also annotate a single field or constructor parameter of a class using `@MappableField()`
-to set a specific json key or add custom hooks.
+to set a specific json key, add custom hooks, or control field inclusion during serialization/deserialization.
 
 ```dart
 @MappableClass()
 class MyClass with MyClassMappable {
-  MyClass(this.value);
+  MyClass(this.value, this.password, this.lastLogin);
 
   @MappableField(key: 'my_key')
   String value;
+
+  // Exclude from JSON output
+  @MappableField(includeToJson: false)
+  String? password;
+
+  // Ignore during deserialization
+  @MappableField(includeFromJson: false)
+  DateTime? lastLogin;
+
+  // Always include even if null
+  @MappableField(includeIfNull: true)
+  String? metadata;
 }
 ```
 
-***Note**: This can only be used on a field if it is directly assigned as a constructor parameter (`MyClass(this.myField)`).
-Setting this annotation on any other field will have no effect.
-(Read [Utilizing Constructors](https://pub.dev/documentation/dart_mappable/latest/topics/Models-topic.html#utilizing-constructors) for an explanation why this is.)*
+**Field Ignoring Options:**
 
-***Tip**: Hooks are a way to customize the serialization of any field or class.
-Read more in the documentation about [Mapping Hooks](https://pub.dev/documentation/dart_mappable/latest/topics/Mapping%20Hooks-topic.html).*
+- `includeToJson`: Controls whether the field is included when encoding to JSON/Map
+- `includeFromJson`: Controls whether the field is set during deserialization from JSON/Map
+- `includeIfNull`: Controls whether null values are included, overriding class-level `ignoreNull`
+
+**\*Note**: This can only be used on a field if it is directly assigned as a constructor parameter (`MyClass(this.myField)`).
+Setting this annotation on any other field will have no effect.
+(Read [Utilizing Constructors](https://pub.dev/documentation/dart_mappable/latest/topics/Models-topic.html#utilizing-constructors) for an explanation why this is.)\*
+
+**\*Tip**: Hooks are a way to customize the serialization of any field or class.
+Read more in the documentation about [Mapping Hooks](https://pub.dev/documentation/dart_mappable/latest/topics/Mapping%20Hooks-topic.html).\*
 
 You can add the `@MappableLib()` annotation to your `library` statement to set a default configuration
 for all included classes and enums, e.g. the case style for json keys.
@@ -197,7 +215,7 @@ class MyClass with MyClassMappable {
 }
 ```
 
-***Tip**: Check out the documentation to see all available [Configuration](https://pub.dev/documentation/dart_mappable/latest/topics/Configuration-topic.html) options.*
+**\*Tip**: Check out the documentation to see all available [Configuration](https://pub.dev/documentation/dart_mappable/latest/topics/Configuration-topic.html) options.\*
 
 ---
 
@@ -205,7 +223,7 @@ Here are again all **six** annotations that you can use in your code:
 
 1. `@MappableClass()` can be used on a class to specify options like the `caseStyle` of the json keys, whether to ignore null values, or [hooks](https://pub.dev/documentation/dart_mappable/latest/topics/Mapping%20Hooks-topic.html).
 2. `@MappableConstructor()` can be used on a constructor to mark this to be used for decoding. It has no properties.
-3. `@MappableField()` can be used on a constructor parameter or a field to specify a json key to be used instead of the field name, or [hooks](https://pub.dev/documentation/dart_mappable/latest/topics/Mapping%20Hooks-topic.html).
+3. `@MappableField()` can be used on a constructor parameter or a field to specify a json key to be used instead of the field name, add [hooks](https://pub.dev/documentation/dart_mappable/latest/topics/Mapping%20Hooks-topic.html), or control field inclusion during serialization/deserialization (`includeToJson`, `includeFromJson`, `includeIfNull`).
 4. `@MappableEnum()` can be used on an enum to specify the `mode` or `caseStyle` of the encoded enum values, or the `defaultValue`.
 5. `@MappableValue()` can be used on an enum value to specify a custom encoded value to use.
 6. `@MappableLib()` can be used on a library statement or import / export statement to set a default configuration for the annotated library or include / exclude classes.
@@ -217,8 +235,8 @@ Here are again all **six** annotations that you can use in your code:
 - `<ClassName>Mapper.fromMap<T>(Map<String, dynamic> map)` will take an encoded map object and return a decoded object of type `ClassName`.
 - `<ClassName>Mapper.fromJson<T>(String json)` internally uses `fromMap` but works with json encoded `String`s.
 
-***Tip**: If you prefer to use `MyClass.fromJson` over `MyClassMapper.fromJson`, add the `fromJson` and
-`fromMap` methods directly to your class like this:*
+**\*Tip**: If you prefer to use `MyClass.fromJson` over `MyClassMapper.fromJson`, add the `fromJson` and
+`fromMap` methods directly to your class like this:\*
 
 ```
 class MyClass with MyClassMappable {
@@ -240,26 +258,26 @@ The generated `<ClassName>Mappable` mixin will come with the following methods:
 See the full documentation [here](https://pub.dev/documentation/dart_mappable/latest/topics/Introduction-topic.html)
 or jump directly to the topic you are looking for:
 
-- [**Models**](https://pub.dev/documentation/dart_mappable/latest/topics/Models-topic.html) 
+- [**Models**](https://pub.dev/documentation/dart_mappable/latest/topics/Models-topic.html)
   show you how to structure and annotate your data models.
-- [**Enums**](https://pub.dev/documentation/dart_mappable/latest/topics/Enums-topic.html) 
+- [**Enums**](https://pub.dev/documentation/dart_mappable/latest/topics/Enums-topic.html)
   show you how to structure and annotate your enums.
 - [**Records**](https://pub.dev/documentation/dart_mappable/latest/topics/Records-topic.html)
   show you how to use records as part of your models.
-- [**Configuration**](https://pub.dev/documentation/dart_mappable/latest/topics/Configuration-topic.html) 
+- [**Configuration**](https://pub.dev/documentation/dart_mappable/latest/topics/Configuration-topic.html)
   goes into the different configuration options you have.
-- [**Copy-With**](https://pub.dev/documentation/dart_mappable/latest/topics/Copy-With-topic.html) 
+- [**Copy-With**](https://pub.dev/documentation/dart_mappable/latest/topics/Copy-With-topic.html)
   describes the copy-with functionalities and how to use them.
-- [**Polymorphism**](https://pub.dev/documentation/dart_mappable/latest/topics/Polymorphism-topic.html) 
+- [**Polymorphism**](https://pub.dev/documentation/dart_mappable/latest/topics/Polymorphism-topic.html)
   shows how to do polymorphic classes and inheritance.
-- [**Generics**](https://pub.dev/documentation/dart_mappable/latest/topics/Generics-topic.html) 
+- [**Generics**](https://pub.dev/documentation/dart_mappable/latest/topics/Generics-topic.html)
   explain generic decoding and how to use it.
-- [**Mapping Hooks**](https://pub.dev/documentation/dart_mappable/latest/topics/Mapping%20Hooks-topic.html) 
-  shows how to use hooks to customize your de- and encoding process. 
-- [**Custom Mappers**](https://pub.dev/documentation/dart_mappable/latest/topics/Custom%20Mappers-topic.html) 
+- [**Mapping Hooks**](https://pub.dev/documentation/dart_mappable/latest/topics/Mapping%20Hooks-topic.html)
+  shows how to use hooks to customize your de- and encoding process.
+- [**Custom Mappers**](https://pub.dev/documentation/dart_mappable/latest/topics/Custom%20Mappers-topic.html)
   explains how to set up and use (non-generated) custom mappers.
-- [**Mapper Container**](https://pub.dev/documentation/dart_mappable/latest/topics/Mapper%20Container-topic.html) 
+- [**Mapper Container**](https://pub.dev/documentation/dart_mappable/latest/topics/Mapper%20Container-topic.html)
   describes the inner workings of mapper containers in more detail.
-- [**Migration and Compatibility**](https://pub.dev/documentation/dart_mappable/latest/topics/Migration%20and%20Compatibility-topic.html) 
-  shows you how you can incrementally migrate from other packages like freezed or json_serializable and use compatible 
+- [**Migration and Compatibility**](https://pub.dev/documentation/dart_mappable/latest/topics/Migration%20and%20Compatibility-topic.html)
+  shows you how you can incrementally migrate from other packages like freezed or json_serializable and use compatible
   packages like fast_immutable_collections.

--- a/packages/dart_mappable/example/lib/main.dart
+++ b/packages/dart_mappable/example/lib/main.dart
@@ -7,8 +7,27 @@ class Person with PersonMappable {
   final String name;
   final int age;
   final Car? car;
+  @MappableField(includeFromJson: false)
+  final String? description;
+  @MappableField(includeToJson: false)
+  final String? secret;
+  @MappableField(includeIfNull: false)
+  final String? metadata;
+  @MappableField(includeIfNull: true)
+  final String? password;
+  @MappableField(includeFromJson: false, includeToJson: false)
+  final String? lastLogin;
 
-  Person(this.name, {this.age = 18, this.car});
+  Person(
+    this.name, {
+    this.age = 18,
+    this.car,
+    this.description,
+    this.secret,
+    this.metadata,
+    this.password,
+    this.lastLogin,
+  });
 }
 
 @MappableEnum()
@@ -39,7 +58,8 @@ class Confetti with ConfettiMappable {
 
 void main() {
   // decode from json string
-  String json = '{"name": "Max", "car": {"miles": 1000, "brand": "Audi"}}';
+  String json =
+      '{"name": "Max", "car": {"miles": 1000, "brand": "Audi"}, "description": "Max is a good boy", "secret": "secret123", "metadata": "metadata123", "password": "password123", "lastLogin": "2023-01-01T00:00:00.000Z"}';
   Person person = PersonMapper.fromJson(json);
 
   // use toString()
@@ -47,8 +67,37 @@ void main() {
   // Person(name: Max, age: 18, car: Car(miles: 1000.0, brand: Brand.Audi))
 
   // make a copy
-  Person person2 = person.copyWith(name: 'Anna', age: 20);
+  Person person2 = person.copyWith(
+      name: 'Anna',
+      age: 20,
+      description: 'Anna is a good girl',
+      secret: 'secret456',
+      metadata: 'metadata456',
+      password: 'password456',
+      lastLogin: '2023-01-02T00:00:00.000Z');
   print(person2); // Person(name: Anna, age: 20, car: ...
+
+  // check description for toMap when (includeFromJson: false)
+  final map2 = person2.toMap();
+  print(map2);
+
+  // check secret for toMap when (includeToJson: false)
+  final map3 = person2.toMap();
+  print(map3);
+
+  // check metadata for toMap when (includeIfNull: true)
+
+  // check password for toMap when (includeIfNull: false)
+  final map4 = person2.toMap();
+  print(map4);
+
+  // check lastLogin for toMap when (includeFromJson: false, includeToJson: false)
+  final map5 = person2.toMap();
+  print(map5);
+
+  // check all fields for toMap
+  final map6 = person2.toMap();
+  print(map6);
 
   // encode to map
   Map<String, dynamic> map = person.toMap();

--- a/packages/dart_mappable/example/lib/main.mapper.dart
+++ b/packages/dart_mappable/example/lib/main.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -25,11 +26,11 @@ class BrandMapper extends EnumMapper<Brand> {
   @override
   Brand decode(dynamic value) {
     switch (value) {
-      case 'Toyota':
+      case r'Toyota':
         return Brand.Toyota;
-      case 'Audi':
+      case r'Audi':
         return Brand.Audi;
-      case 'BMW':
+      case r'BMW':
         return Brand.BMW;
       default:
         throw MapperException.unknownEnumValue(value);
@@ -40,11 +41,11 @@ class BrandMapper extends EnumMapper<Brand> {
   dynamic encode(Brand self) {
     switch (self) {
       case Brand.Toyota:
-        return 'Toyota';
+        return r'Toyota';
       case Brand.Audi:
-        return 'Audi';
+        return r'Audi';
       case Brand.BMW:
-        return 'BMW';
+        return r'BMW';
     }
   }
 }
@@ -72,23 +73,101 @@ class PersonMapper extends ClassMapperBase<Person> {
   final String id = 'Person';
 
   static String _$name(Person v) => v.name;
-  static const Field<Person, String> _f$name = Field('name', _$name);
+  static const Field<Person, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$age(Person v) => v.age;
-  static const Field<Person, int> _f$age =
-      Field('age', _$age, opt: true, def: 18);
+  static const Field<Person, int> _f$age = Field(
+    'age',
+    _$age,
+    opt: true,
+    def: 18,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Car? _$car(Person v) => v.car;
-  static const Field<Person, Car> _f$car = Field('car', _$car, opt: true);
+  static const Field<Person, Car> _f$car = Field(
+    'car',
+    _$car,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
+  static String? _$description(Person v) => v.description;
+  static const Field<Person, String> _f$description = Field(
+    'description',
+    _$description,
+    opt: true,
+    includeFromJson: false,
+    includeToJson: true,
+    includeIfNull: false,
+  );
+  static String? _$secret(Person v) => v.secret;
+  static const Field<Person, String> _f$secret = Field(
+    'secret',
+    _$secret,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: false,
+    includeIfNull: false,
+  );
+  static String? _$metadata(Person v) => v.metadata;
+  static const Field<Person, String> _f$metadata = Field(
+    'metadata',
+    _$metadata,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
+  static String? _$password(Person v) => v.password;
+  static const Field<Person, String> _f$password = Field(
+    'password',
+    _$password,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: true,
+  );
+  static String? _$lastLogin(Person v) => v.lastLogin;
+  static const Field<Person, String> _f$lastLogin = Field(
+    'lastLogin',
+    _$lastLogin,
+    opt: true,
+    includeFromJson: false,
+    includeToJson: false,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Person> fields = const {
     #name: _f$name,
     #age: _f$age,
     #car: _f$car,
+    #description: _f$description,
+    #secret: _f$secret,
+    #metadata: _f$metadata,
+    #password: _f$password,
+    #lastLogin: _f$lastLogin,
   };
 
   static Person _instantiate(DecodingData data) {
-    return Person(data.dec(_f$name),
-        age: data.dec(_f$age), car: data.dec(_f$car));
+    return Person(
+      data.dec(_f$name),
+      age: data.dec(_f$age),
+      car: data.dec(_f$car),
+      description: null,
+      secret: data.dec(_f$secret),
+      metadata: data.dec(_f$metadata),
+      password: data.dec(_f$password),
+      lastLogin: null,
+    );
   }
 
   @override
@@ -113,7 +192,7 @@ mixin PersonMappable {
   }
 
   PersonCopyWith<Person, Person, Person> get copyWith =>
-      _PersonCopyWithImpl(this as Person, $identity, $identity);
+      _PersonCopyWithImpl<Person, Person>(this as Person, $identity, $identity);
   @override
   String toString() {
     return PersonMapper.ensureInitialized().stringifyValue(this as Person);
@@ -132,13 +211,22 @@ mixin PersonMappable {
 
 extension PersonValueCopy<$R, $Out> on ObjectCopyWith<$R, Person, $Out> {
   PersonCopyWith<$R, Person, $Out> get $asPerson =>
-      $base.as((v, t, t2) => _PersonCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _PersonCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class PersonCopyWith<$R, $In extends Person, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
   CarCopyWith<$R, Car, Car>? get car;
-  $R call({String? name, int? age, Car? car});
+  $R call({
+    String? name,
+    int? age,
+    Car? car,
+    String? description,
+    String? secret,
+    String? metadata,
+    String? password,
+    String? lastLogin,
+  });
   PersonCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -152,19 +240,42 @@ class _PersonCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Person, $Out>
   CarCopyWith<$R, Car, Car>? get car =>
       $value.car?.copyWith.$chain((v) => call(car: v));
   @override
-  $R call({String? name, int? age, Object? car = $none}) =>
-      $apply(FieldCopyWithData({
-        if (name != null) #name: name,
-        if (age != null) #age: age,
-        if (car != $none) #car: car
-      }));
+  $R call({
+    String? name,
+    int? age,
+    Object? car = $none,
+    Object? description = $none,
+    Object? secret = $none,
+    Object? metadata = $none,
+    Object? password = $none,
+    Object? lastLogin = $none,
+  }) => $apply(
+    FieldCopyWithData({
+      if (name != null) #name: name,
+      if (age != null) #age: age,
+      if (car != $none) #car: car,
+      if (description != $none) #description: description,
+      if (secret != $none) #secret: secret,
+      if (metadata != $none) #metadata: metadata,
+      if (password != $none) #password: password,
+      if (lastLogin != $none) #lastLogin: lastLogin,
+    }),
+  );
   @override
-  Person $make(CopyWithData data) => Person(data.get(#name, or: $value.name),
-      age: data.get(#age, or: $value.age), car: data.get(#car, or: $value.car));
+  Person $make(CopyWithData data) => Person(
+    data.get(#name, or: $value.name),
+    age: data.get(#age, or: $value.age),
+    car: data.get(#car, or: $value.car),
+    description: data.get(#description, or: $value.description),
+    secret: data.get(#secret, or: $value.secret),
+    metadata: data.get(#metadata, or: $value.metadata),
+    password: data.get(#password, or: $value.password),
+    lastLogin: data.get(#lastLogin, or: $value.lastLogin),
+  );
 
   @override
   PersonCopyWith<$R2, Person, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _PersonCopyWithImpl($value, $cast, t);
+      _PersonCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
 class CarMapper extends ClassMapperBase<Car> {
@@ -183,15 +294,24 @@ class CarMapper extends ClassMapperBase<Car> {
   final String id = 'Car';
 
   static double _$miles(Car v) => v.miles;
-  static const Field<Car, double> _f$miles = Field('miles', _$miles);
+  static const Field<Car, double> _f$miles = Field(
+    'miles',
+    _$miles,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Brand _$brand(Car v) => v.brand;
-  static const Field<Car, Brand> _f$brand = Field('brand', _$brand);
+  static const Field<Car, Brand> _f$brand = Field(
+    'brand',
+    _$brand,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
-  final MappableFields<Car> fields = const {
-    #miles: _f$miles,
-    #brand: _f$brand,
-  };
+  final MappableFields<Car> fields = const {#miles: _f$miles, #brand: _f$brand};
 
   static Car _instantiate(DecodingData data) {
     return Car(data.dec(_f$miles), data.dec(_f$brand));
@@ -219,7 +339,7 @@ mixin CarMappable {
   }
 
   CarCopyWith<Car, Car, Car> get copyWith =>
-      _CarCopyWithImpl(this as Car, $identity, $identity);
+      _CarCopyWithImpl<Car, Car>(this as Car, $identity, $identity);
   @override
   String toString() {
     return CarMapper.ensureInitialized().stringifyValue(this as Car);
@@ -238,7 +358,7 @@ mixin CarMappable {
 
 extension CarValueCopy<$R, $Out> on ObjectCopyWith<$R, Car, $Out> {
   CarCopyWith<$R, Car, $Out> get $asCar =>
-      $base.as((v, t, t2) => _CarCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _CarCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class CarCopyWith<$R, $In extends Car, $Out>
@@ -254,15 +374,21 @@ class _CarCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Car, $Out>
   @override
   late final ClassMapperBase<Car> $mapper = CarMapper.ensureInitialized();
   @override
-  $R call({double? miles, Brand? brand}) => $apply(FieldCopyWithData(
-      {if (miles != null) #miles: miles, if (brand != null) #brand: brand}));
+  $R call({double? miles, Brand? brand}) => $apply(
+    FieldCopyWithData({
+      if (miles != null) #miles: miles,
+      if (brand != null) #brand: brand,
+    }),
+  );
   @override
   Car $make(CopyWithData data) => Car(
-      data.get(#miles, or: $value.miles), data.get(#brand, or: $value.brand));
+    data.get(#miles, or: $value.miles),
+    data.get(#brand, or: $value.brand),
+  );
 
   @override
   CarCopyWith<$R2, Car, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _CarCopyWithImpl($value, $cast, t);
+      _CarCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
 class BoxMapper extends ClassMapperBase<Box> {
@@ -279,14 +405,27 @@ class BoxMapper extends ClassMapperBase<Box> {
   @override
   final String id = 'Box';
   @override
-  Function get typeFactory => <T>(f) => f<Box<T>>();
+  Function get typeFactory =>
+      <T>(f) => f<Box<T>>();
 
   static int _$size(Box v) => v.size;
-  static const Field<Box, int> _f$size = Field('size', _$size);
+  static const Field<Box, int> _f$size = Field(
+    'size',
+    _$size,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static dynamic _$content(Box v) => v.content;
   static dynamic _arg$content<T>(f) => f<T>();
-  static const Field<Box, dynamic> _f$content =
-      Field('content', _$content, arg: _arg$content);
+  static const Field<Box, dynamic> _f$content = Field(
+    'content',
+    _$content,
+    arg: _arg$content,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Box> fields = const {
@@ -320,7 +459,7 @@ mixin BoxMappable<T> {
   }
 
   BoxCopyWith<Box<T>, Box<T>, Box<T>, T> get copyWith =>
-      _BoxCopyWithImpl(this as Box<T>, $identity, $identity);
+      _BoxCopyWithImpl<Box<T>, Box<T>, T>(this as Box<T>, $identity, $identity);
   @override
   String toString() {
     return BoxMapper.ensureInitialized().stringifyValue(this as Box<T>);
@@ -339,7 +478,7 @@ mixin BoxMappable<T> {
 
 extension BoxValueCopy<$R, $Out, T> on ObjectCopyWith<$R, Box<T>, $Out> {
   BoxCopyWith<$R, Box<T>, $Out, T> get $asBox =>
-      $base.as((v, t, t2) => _BoxCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _BoxCopyWithImpl<$R, $Out, T>(v, t, t2));
 }
 
 abstract class BoxCopyWith<$R, $In extends Box<T>, $Out, T>
@@ -355,15 +494,21 @@ class _BoxCopyWithImpl<$R, $Out, T> extends ClassCopyWithBase<$R, Box<T>, $Out>
   @override
   late final ClassMapperBase<Box> $mapper = BoxMapper.ensureInitialized();
   @override
-  $R call({int? size, T? content}) => $apply(FieldCopyWithData(
-      {if (size != null) #size: size, if (content != null) #content: content}));
+  $R call({int? size, Object? content = $none}) => $apply(
+    FieldCopyWithData({
+      if (size != null) #size: size,
+      if (content != $none) #content: content,
+    }),
+  );
   @override
-  Box<T> $make(CopyWithData data) => Box(data.get(#size, or: $value.size),
-      content: data.get(#content, or: $value.content));
+  Box<T> $make(CopyWithData data) => Box(
+    data.get(#size, or: $value.size),
+    content: data.get(#content, or: $value.content),
+  );
 
   @override
   BoxCopyWith<$R2, Box<T>, $Out2, T> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _BoxCopyWithImpl($value, $cast, t);
+      _BoxCopyWithImpl<$R2, $Out2, T>($value, $cast, t);
 }
 
 class ConfettiMapper extends ClassMapperBase<Confetti> {
@@ -381,12 +526,16 @@ class ConfettiMapper extends ClassMapperBase<Confetti> {
   final String id = 'Confetti';
 
   static String _$color(Confetti v) => v.color;
-  static const Field<Confetti, String> _f$color = Field('color', _$color);
+  static const Field<Confetti, String> _f$color = Field(
+    'color',
+    _$color,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
-  final MappableFields<Confetti> fields = const {
-    #color: _f$color,
-  };
+  final MappableFields<Confetti> fields = const {#color: _f$color};
 
   static Confetti _instantiate(DecodingData data) {
     return Confetti(data.dec(_f$color));
@@ -406,17 +555,23 @@ class ConfettiMapper extends ClassMapperBase<Confetti> {
 
 mixin ConfettiMappable {
   String toJson() {
-    return ConfettiMapper.ensureInitialized()
-        .encodeJson<Confetti>(this as Confetti);
+    return ConfettiMapper.ensureInitialized().encodeJson<Confetti>(
+      this as Confetti,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return ConfettiMapper.ensureInitialized()
-        .encodeMap<Confetti>(this as Confetti);
+    return ConfettiMapper.ensureInitialized().encodeMap<Confetti>(
+      this as Confetti,
+    );
   }
 
   ConfettiCopyWith<Confetti, Confetti, Confetti> get copyWith =>
-      _ConfettiCopyWithImpl(this as Confetti, $identity, $identity);
+      _ConfettiCopyWithImpl<Confetti, Confetti>(
+        this as Confetti,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
     return ConfettiMapper.ensureInitialized().stringifyValue(this as Confetti);
@@ -424,8 +579,10 @@ mixin ConfettiMappable {
 
   @override
   bool operator ==(Object other) {
-    return ConfettiMapper.ensureInitialized()
-        .equalsValue(this as Confetti, other);
+    return ConfettiMapper.ensureInitialized().equalsValue(
+      this as Confetti,
+      other,
+    );
   }
 
   @override
@@ -436,7 +593,7 @@ mixin ConfettiMappable {
 
 extension ConfettiValueCopy<$R, $Out> on ObjectCopyWith<$R, Confetti, $Out> {
   ConfettiCopyWith<$R, Confetti, $Out> get $asConfetti =>
-      $base.as((v, t, t2) => _ConfettiCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _ConfettiCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class ConfettiCopyWith<$R, $In extends Confetti, $Out>
@@ -462,6 +619,7 @@ class _ConfettiCopyWithImpl<$R, $Out>
 
   @override
   ConfettiCopyWith<$R2, Confetti, $Out2> $chain<$R2, $Out2>(
-          Then<$Out2, $R2> t) =>
-      _ConfettiCopyWithImpl($value, $cast, t);
+    Then<$Out2, $R2> t,
+  ) => _ConfettiCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/packages/dart_mappable/lib/src/annotations.dart
+++ b/packages/dart_mappable/lib/src/annotations.dart
@@ -145,13 +145,38 @@ class MappableConstructor {
 /// {@category Configuration}
 /// {@category Mapping Hooks}
 class MappableField {
-  const MappableField({this.key, this.hook});
+  const MappableField({
+    this.key,
+    this.hook,
+    this.includeFromJson,
+    this.includeToJson,
+    this.includeIfNull,
+  });
 
   /// Use this key instead of the field name.
   final String? key;
 
   /// Define custom hooks used only for this field.
   final MappingHook? hook;
+
+  /// Whether to include this field during deserialization (fromJson/fromMap).
+  ///
+  /// If false, this field will be ignored when decoding from JSON/Map.
+  /// Defaults to true.
+  final bool? includeFromJson;
+
+  /// Whether to include this field during serialization (toJson/toMap).
+  ///
+  /// If false, this field will be ignored when encoding to JSON/Map.
+  /// Defaults to true.
+  final bool? includeToJson;
+
+  /// Whether to include this field even if its value is null.
+  ///
+  /// This overrides the class-level [ignoreNull] setting for this specific field.
+  /// If true, null values will be included in serialization.
+  /// Defaults to false (respects class-level ignoreNull setting).
+  final bool? includeIfNull;
 }
 
 /// Used to annotate a record in order to generate mapping code.

--- a/packages/dart_mappable/lib/src/mappers/class_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/class_mapper.dart
@@ -147,7 +147,12 @@ abstract class ClassMapperBase<T extends Object>
   /// See [FieldMode] for more.
   late final List<Field<T, dynamic>> _params =
       fields.values
-          .where((f) => f.mode != FieldMode.member && f.getter != null)
+          .where(
+            (f) =>
+                f.mode != FieldMode.member &&
+                f.getter != null &&
+                f.includeFromJson,
+          )
           .toList();
 
   @override

--- a/packages/dart_mappable/lib/src/mappers/class_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/class_mapper.dart
@@ -155,6 +155,12 @@ abstract class ClassMapperBase<T extends Object>
           )
           .toList();
 
+  /// The set of fields to include during encoding.
+  late final List<Field<T, dynamic>> _encodingParams =
+      fields.values
+          .where((f) => f.mode != FieldMode.member && f.getter != null)
+          .toList();
+
   @override
   T decoder(Object? value, DecodingContext context) {
     if (superHook != null && !context.inherited) {
@@ -219,7 +225,7 @@ abstract class ClassMapperBase<T extends Object>
   Object? encode(T value, EncodingContext context) {
     var result = InterfaceMapperBase.encodeFields(
       value,
-      _params,
+      _encodingParams,
       ignoreNull,
       context,
       context.options?.shallow ?? shallowEncoding,

--- a/packages/dart_mappable/pubspec.yaml
+++ b/packages/dart_mappable/pubspec.yaml
@@ -8,7 +8,7 @@ funding:
   - https://github.com/sponsors/schultek
 
 environment:
-  sdk: '>=3.7.0 <4.0.0'
+  sdk: ">=3.7.0 <4.0.0"
 
 topics:
   - json
@@ -23,7 +23,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.14
-  dart_mappable_builder: ^4.6.1
+  dart_mappable_builder:
+    path: ../dart_mappable_builder
   lints: ^5.0.0
   test: ^1.25.10
-

--- a/packages/dart_mappable/test/copy_with/collection_copy_with_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/collection_copy_with_test.mapper.dart
@@ -30,6 +30,9 @@ class AMapper extends ClassMapperBase<A> {
     'items',
     _$items,
     arg: _arg$items,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -136,6 +139,9 @@ class BMapper extends ClassMapperBase<B> {
     'items',
     _$items,
     arg: _arg$items,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/copy_with/copy_with_data_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/copy_with_data_test.mapper.dart
@@ -23,9 +23,21 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static String? _$a(A v) => v.a;
-  static const Field<A, String> _f$a = Field('a', _$a);
+  static const Field<A, String> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static B? _$b(A v) => v.b;
-  static const Field<A, B> _f$b = Field('b', _$b);
+  static const Field<A, B> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#a: _f$a, #b: _f$b};
@@ -120,9 +132,21 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static String? _$a(B v) => v.a;
-  static const Field<B, String> _f$a = Field('a', _$a);
+  static const Field<B, String> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int? _$b(B v) => v.b;
-  static const Field<B, int> _f$b = Field('b', _$b);
+  static const Field<B, int> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#a: _f$a, #b: _f$b};

--- a/packages/dart_mappable/test/copy_with/copy_with_generic_bounded_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/copy_with_generic_bounded_test.mapper.dart
@@ -31,6 +31,9 @@ class ContainerMapper extends ClassMapperBase<Container> {
     'content',
     _$content,
     arg: _arg$content,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -154,7 +157,14 @@ class AMapper extends ClassMapperBase<A> {
 
   static B _$b(A v) => v.b;
   static dynamic _arg$b<T extends B>(f) => f<T>();
-  static const Field<A, B> _f$b = Field('b', _$b, arg: _arg$b);
+  static const Field<A, B> _f$b = Field(
+    'b',
+    _$b,
+    arg: _arg$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#b: _f$b};
@@ -249,7 +259,13 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static String _$b(B v) => v.b;
-  static const Field<B, String> _f$b = Field('b', _$b);
+  static const Field<B, String> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#b: _f$b};
@@ -348,6 +364,9 @@ class Container1Mapper extends ClassMapperBase<Container1> {
     'content',
     _$content,
     arg: _arg$content,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -478,6 +497,9 @@ class Container2Mapper extends ClassMapperBase<Container2> {
     'content',
     _$content,
     arg: _arg$content,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -615,6 +637,9 @@ class Container3Mapper extends ClassMapperBase<Container3> {
     'content',
     _$content,
     arg: _arg$content,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static List<A2<dynamic>> _$contents(Container3 v) => v.contents;
   static dynamic _arg$contents<T extends A2<dynamic>>(f) => f<List<T>>();
@@ -622,6 +647,9 @@ class Container3Mapper extends ClassMapperBase<Container3> {
     'contents',
     _$contents,
     arg: _arg$contents,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -765,7 +793,14 @@ class A2Mapper extends ClassMapperBase<A2> {
 
   static dynamic _$t(A2 v) => v.t;
   static dynamic _arg$t<T>(f) => f<T>();
-  static const Field<A2, dynamic> _f$t = Field('t', _$t, arg: _arg$t);
+  static const Field<A2, dynamic> _f$t = Field(
+    't',
+    _$t,
+    arg: _arg$t,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A2> fields = const {#t: _f$t};
@@ -865,6 +900,9 @@ class Container4Mapper extends ClassMapperBase<Container4> {
     'content',
     _$content,
     arg: _arg$content,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static List<A2<B>> _$contents(Container4 v) => v.contents;
   static dynamic _arg$contents<T extends A2<B>>(f) => f<List<T>>();
@@ -872,6 +910,9 @@ class Container4Mapper extends ClassMapperBase<Container4> {
     'contents',
     _$contents,
     arg: _arg$contents,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -1017,6 +1058,9 @@ class Container5Mapper extends ClassMapperBase<Container5> {
     'content',
     _$content,
     arg: _arg$content,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -1138,7 +1182,13 @@ class B2Mapper extends ClassMapperBase<B2> {
   final String id = 'B2';
 
   static String _$b(B2 v) => v.b;
-  static const Field<B2, String> _f$b = Field('b', _$b);
+  static const Field<B2, String> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B2> fields = const {#b: _f$b};

--- a/packages/dart_mappable/test/copy_with/copy_with_generic_poly_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/copy_with_generic_poly_test.mapper.dart
@@ -28,7 +28,14 @@ class AMapper extends ClassMapperBase<A> {
 
   static C _$value(A v) => v.value;
   static dynamic _arg$value<T extends C>(f) => f<T>();
-  static const Field<A, C> _f$value = Field('value', _$value, arg: _arg$value);
+  static const Field<A, C> _f$value = Field(
+    'value',
+    _$value,
+    arg: _arg$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#value: _f$value};
@@ -125,7 +132,13 @@ class CMapper extends ClassMapperBase<C> {
   final String id = 'C';
 
   static String _$data(C v) => v.data;
-  static const Field<C, String> _f$data = Field('data', _$data);
+  static const Field<C, String> _f$data = Field(
+    'data',
+    _$data,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<C> fields = const {#data: _f$data};
@@ -175,7 +188,13 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static D _$value(B v) => v.value;
-  static const Field<B, D> _f$value = Field('value', _$value);
+  static const Field<B, D> _f$value = Field(
+    'value',
+    _$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#value: _f$value};
@@ -273,7 +292,13 @@ class DMapper extends ClassMapperBase<D> {
   final String id = 'D';
 
   static String _$data(D v) => v.data;
-  static const Field<D, String> _f$data = Field('data', _$data);
+  static const Field<D, String> _f$data = Field(
+    'data',
+    _$data,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<D> fields = const {#data: _f$data};

--- a/packages/dart_mappable/test/copy_with/copy_with_subtype_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/copy_with_subtype_test.mapper.dart
@@ -24,7 +24,13 @@ class AnimalMapper extends ClassMapperBase<Animal> {
   final String id = 'Animal';
 
   static String _$name(Animal v) => v.name;
-  static const Field<Animal, String> _f$name = Field('name', _$name);
+  static const Field<Animal, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Animal> fields = const {#name: _f$name};
@@ -67,9 +73,21 @@ class CatMapper extends SubClassMapperBase<Cat> {
   final String id = 'Cat';
 
   static String _$name(Cat v) => v.name;
-  static const Field<Cat, String> _f$name = Field('name', _$name);
+  static const Field<Cat, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$color(Cat v) => v.color;
-  static const Field<Cat, String> _f$color = Field('color', _$color);
+  static const Field<Cat, String> _f$color = Field(
+    'color',
+    _$color,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Cat> fields = const {#name: _f$name, #color: _f$color};
@@ -148,7 +166,13 @@ class DogMapper extends SubClassMapperBase<Dog> {
   final String id = 'Dog';
 
   static String _$name(Dog v) => v.name;
-  static const Field<Dog, String> _f$name = Field('name', _$name);
+  static const Field<Dog, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Dog> fields = const {#name: _f$name};
@@ -222,7 +246,13 @@ class ZooMapper extends ClassMapperBase<Zoo> {
   final String id = 'Zoo';
 
   static Animal _$animal(Zoo v) => v.animal;
-  static const Field<Zoo, Animal> _f$animal = Field('animal', _$animal);
+  static const Field<Zoo, Animal> _f$animal = Field(
+    'animal',
+    _$animal,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Zoo> fields = const {#animal: _f$animal};
@@ -475,9 +505,21 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static List<A<dynamic>?> _$list(B v) => v.list;
-  static const Field<B, List<A<dynamic>?>> _f$list = Field('list', _$list);
+  static const Field<B, List<A<dynamic>?>> _f$list = Field(
+    'list',
+    _$list,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static A<dynamic>? _$a(B v) => v.a;
-  static const Field<B, A<dynamic>> _f$a = Field('a', _$a);
+  static const Field<B, A<dynamic>> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#list: _f$list, #a: _f$a};

--- a/packages/dart_mappable/test/copy_with/copy_with_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/copy_with_test.mapper.dart
@@ -23,9 +23,21 @@ class PersonMapper extends ClassMapperBase<Person> {
   final String id = 'Person';
 
   static String _$name(Person v) => v.name;
-  static const Field<Person, String> _f$name = Field('name', _$name);
+  static const Field<Person, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Car _$car(Person v) => v.car;
-  static const Field<Person, Car> _f$car = Field('car', _$car);
+  static const Field<Person, Car> _f$car = Field(
+    'car',
+    _$car,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Person> fields = const {#name: _f$name, #car: _f$car};
@@ -126,9 +138,21 @@ class CarMapper extends ClassMapperBase<Car> {
   final String id = 'Car';
 
   static Brand? _$brand(Car v) => v.brand;
-  static const Field<Car, Brand> _f$brand = Field('brand', _$brand);
+  static const Field<Car, Brand> _f$brand = Field(
+    'brand',
+    _$brand,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$model(Car v) => v.model;
-  static const Field<Car, String> _f$model = Field('model', _$model);
+  static const Field<Car, String> _f$model = Field(
+    'model',
+    _$model,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Car> fields = const {#brand: _f$brand, #model: _f$model};
@@ -230,7 +254,13 @@ class BrandMapper extends ClassMapperBase<Brand> {
   final String id = 'Brand';
 
   static dynamic _$name(Brand v) => v.name;
-  static const Field<Brand, dynamic> _f$name = Field('name', _$name);
+  static const Field<Brand, dynamic> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Brand> fields = const {#name: _f$name};
@@ -324,11 +354,20 @@ class DealershipMapper extends ClassMapperBase<Dealership> {
   final String id = 'Dealership';
 
   static List<Car> _$cars(Dealership v) => v.cars;
-  static const Field<Dealership, List<Car>> _f$cars = Field('cars', _$cars);
+  static const Field<Dealership, List<Car>> _f$cars = Field(
+    'cars',
+    _$cars,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Map<Brand, Person?> _$salesRep(Dealership v) => v.salesRep;
   static const Field<Dealership, Map<Brand, Person?>> _f$salesRep = Field(
     'salesRep',
     _$salesRep,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -475,6 +514,9 @@ class ItemListMapper extends ClassMapperBase<ItemList> {
     'items',
     _$items,
     arg: _arg$items,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -534,6 +576,9 @@ class BrandListMapper extends SubClassMapperBase<BrandList> {
     'items',
     _$items,
     key: r'brands',
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -668,13 +713,22 @@ class NamedItemListMapper extends SubClassMapperBase<NamedItemList> {
       <T>(f) => f<NamedItemList<T>>();
 
   static String _$name(NamedItemList v) => v.name;
-  static const Field<NamedItemList, String> _f$name = Field('name', _$name);
+  static const Field<NamedItemList, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static List<dynamic> _$items(NamedItemList v) => v.items;
   static dynamic _arg$items<T>(f) => f<List<T>>();
   static const Field<NamedItemList, List<dynamic>> _f$items = Field(
     'items',
     _$items,
     arg: _arg$items,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -823,6 +877,9 @@ class KeyedItemListMapper extends SubClassMapperBase<KeyedItemList> {
     'key',
     _$key,
     arg: _arg$key,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static List<dynamic> _$items(KeyedItemList v) => v.items;
   static dynamic _arg$items<K, T>(f) => f<List<T>>();
@@ -830,6 +887,9 @@ class KeyedItemListMapper extends SubClassMapperBase<KeyedItemList> {
     'items',
     _$items,
     arg: _arg$items,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -994,7 +1054,14 @@ class ComparableItemListMapper extends SubClassMapperBase<ComparableItemList> {
   static List<Comparable<dynamic>> _$items(ComparableItemList v) => v.items;
   static dynamic _arg$items<T extends Comparable<dynamic>>(f) => f<List<T>>();
   static const Field<ComparableItemList, List<Comparable<dynamic>>> _f$items =
-      Field('items', _$items, arg: _arg$items);
+      Field(
+        'items',
+        _$items,
+        arg: _arg$items,
+        includeFromJson: true,
+        includeToJson: true,
+        includeIfNull: false,
+      );
 
   @override
   final MappableFields<ComparableItemList> fields = const {#items: _f$items};

--- a/packages/dart_mappable/test/copy_with/interface_copy_with_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/interface_copy_with_test.mapper.dart
@@ -23,7 +23,13 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static num _$a(A v) => v.a;
-  static const Field<A, num> _f$a = Field('a', _$a);
+  static const Field<A, num> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#a: _f$a};
@@ -114,7 +120,13 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static String _$b(B v) => v.b;
-  static const Field<B, String> _f$b = Field('b', _$b);
+  static const Field<B, String> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#b: _f$b};
@@ -205,9 +217,21 @@ class CMapper extends ClassMapperBase<C> {
   final String id = 'C';
 
   static int _$a(C v) => v.a;
-  static const Field<C, int> _f$a = Field('a', _$a);
+  static const Field<C, int> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$b(C v) => v.b;
-  static const Field<C, String> _f$b = Field('b', _$b);
+  static const Field<C, String> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<C> fields = const {#a: _f$a, #b: _f$b};

--- a/packages/dart_mappable/test/copy_with/retype_copy_with_test.mapper.dart
+++ b/packages/dart_mappable/test/copy_with/retype_copy_with_test.mapper.dart
@@ -24,9 +24,21 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static V _$v(A v) => v.v;
-  static const Field<A, V> _f$v = Field('v', _$v);
+  static const Field<A, V> _f$v = Field(
+    'v',
+    _$v,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static V _$v2(A v) => v.v2;
-  static const Field<A, V> _f$v2 = Field('v2', _$v2);
+  static const Field<A, V> _f$v2 = Field(
+    'v2',
+    _$v2,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#v: _f$v, #v2: _f$v2};
@@ -128,7 +140,13 @@ class VMapper extends ClassMapperBase<V> {
   final String id = 'V';
 
   static int _$v(V v) => v.v;
-  static const Field<V, int> _f$v = Field('v', _$v);
+  static const Field<V, int> _f$v = Field(
+    'v',
+    _$v,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<V> fields = const {#v: _f$v};
@@ -221,10 +239,24 @@ class BMapper extends ClassMapperBase<B> {
 
   static V _$v(B v) => v.v;
   static dynamic _arg$v(f) => f<V>();
-  static const Field<B, W> _f$v = Field('v', _$v, arg: _arg$v);
+  static const Field<B, W> _f$v = Field(
+    'v',
+    _$v,
+    arg: _arg$v,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static V _$v2(B v) => v.v2;
   static dynamic _arg$v2(f) => f<V>();
-  static const Field<B, W> _f$v2 = Field('v2', _$v2, arg: _arg$v2);
+  static const Field<B, W> _f$v2 = Field(
+    'v2',
+    _$v2,
+    arg: _arg$v2,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#v: _f$v, #v2: _f$v2};
@@ -331,7 +363,13 @@ class WMapper extends ClassMapperBase<W> {
   final String id = 'W';
 
   static int _$v(W v) => v.v;
-  static const Field<W, int> _f$v = Field('v', _$v);
+  static const Field<W, int> _f$v = Field(
+    'v',
+    _$v,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<W> fields = const {#v: _f$v};

--- a/packages/dart_mappable/test/custom_mapper/annotation_test.mapper.dart
+++ b/packages/dart_mappable/test/custom_mapper/annotation_test.mapper.dart
@@ -26,6 +26,9 @@ class PrivateContainerMapper extends ClassMapperBase<PrivateContainer> {
   static const Field<PrivateContainer, MyPrivateClass> _f$value = Field(
     'value',
     _$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -145,6 +148,9 @@ class PrivateContainer2Mapper extends ClassMapperBase<PrivateContainer2> {
   static const Field<PrivateContainer2, MyPrivateClass> _f$value = Field(
     'value',
     _$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/custom_mapper/custom_mapper_test.mapper.dart
+++ b/packages/dart_mappable/test/custom_mapper/custom_mapper_test.mapper.dart
@@ -23,11 +23,20 @@ class TestObjMapper extends ClassMapperBase<TestObj> {
   final String id = 'TestObj';
 
   static BigInt? _$x(TestObj v) => v.x;
-  static const Field<TestObj, BigInt> _f$x = Field('x', _$x);
+  static const Field<TestObj, BigInt> _f$x = Field(
+    'x',
+    _$x,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Map<String, dynamic> _$unmappedProps(TestObj v) => v.unmappedProps;
   static const Field<TestObj, Map<String, dynamic>> _f$unmappedProps = Field(
     'unmappedProps',
     _$unmappedProps,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/enums/enum_map_test.mapper.dart
+++ b/packages/dart_mappable/test/enums/enum_map_test.mapper.dart
@@ -76,6 +76,9 @@ class ClassAMapper extends ClassMapperBase<ClassA> {
   static const Field<ClassA, Map<EnumA, bool?>> _f$someVariable = Field(
     'someVariable',
     _$someVariable,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/equality/class_equality_test.mapper.dart
+++ b/packages/dart_mappable/test/equality/class_equality_test.mapper.dart
@@ -73,15 +73,49 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static String _$a(A v) => v.a;
-  static const Field<A, String> _f$a = Field('a', _$a);
+  static const Field<A, String> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$b(A v) => v.b;
-  static const Field<A, int> _f$b = Field('b', _$b, opt: true, def: 0);
+  static const Field<A, int> _f$b = Field(
+    'b',
+    _$b,
+    opt: true,
+    def: 0,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static double? _$c(A v) => v.c;
-  static const Field<A, double> _f$c = Field('c', _$c, opt: true);
+  static const Field<A, double> _f$c = Field(
+    'c',
+    _$c,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static bool _$d(A v) => v.d;
-  static const Field<A, bool> _f$d = Field('d', _$d);
+  static const Field<A, bool> _f$d = Field(
+    'd',
+    _$d,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static B? _$e(A v) => v.e;
-  static const Field<A, B> _f$e = Field('e', _$e, opt: true);
+  static const Field<A, B> _f$e = Field(
+    'e',
+    _$e,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {
@@ -199,7 +233,13 @@ class BaseMapper extends ClassMapperBase<Base> {
   final String id = 'Base';
 
   static String _$data(Base v) => v.data;
-  static const Field<Base, String> _f$data = Field('data', _$data);
+  static const Field<Base, String> _f$data = Field(
+    'data',
+    _$data,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Base> fields = const {#data: _f$data};
@@ -291,7 +331,13 @@ class SubMapper extends ClassMapperBase<Sub> {
   final String id = 'Sub';
 
   static String _$data(Sub v) => v.data;
-  static const Field<Sub, String> _f$data = Field('data', _$data);
+  static const Field<Sub, String> _f$data = Field(
+    'data',
+    _$data,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Sub> fields = const {#data: _f$data};
@@ -384,7 +430,13 @@ class BaseTypeMapper extends ClassMapperBase<BaseType> {
   final String id = 'BaseType';
 
   static String _$type(BaseType v) => v.type;
-  static const Field<BaseType, String> _f$type = Field('type', _$type);
+  static const Field<BaseType, String> _f$type = Field(
+    'type',
+    _$type,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<BaseType> fields = const {#type: _f$type};
@@ -491,7 +543,13 @@ class SubTypeMapper extends SubClassMapperBase<SubType> {
   final String id = 'SubType';
 
   static String _$type(SubType v) => v.type;
-  static const Field<SubType, String> _f$type = Field('type', _$type);
+  static const Field<SubType, String> _f$type = Field(
+    'type',
+    _$type,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<SubType> fields = const {#type: _f$type};
@@ -611,6 +669,9 @@ class GenericMapper extends ClassMapperBase<Generic> {
     'data',
     _$data,
     arg: _arg$data,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -727,6 +788,9 @@ class WrapperMapper extends ClassMapperBase<Wrapper> {
     'value',
     _$value,
     arg: _arg$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/equality/collection_equality_test.mapper.dart
+++ b/packages/dart_mappable/test/equality/collection_equality_test.mapper.dart
@@ -25,6 +25,9 @@ class SetWrapperMapper extends ClassMapperBase<SetWrapper> {
   static const Field<SetWrapper, Set<String>> _f$values = Field(
     'values',
     _$values,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -137,6 +140,9 @@ class ListWrapperMapper extends ClassMapperBase<ListWrapper> {
   static const Field<ListWrapper, List<String>> _f$values = Field(
     'values',
     _$values,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -257,6 +263,9 @@ class MapWrapperMapper extends ClassMapperBase<MapWrapper> {
   static const Field<MapWrapper, Map<String, dynamic>> _f$values = Field(
     'values',
     _$values,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/equality/function_fields_test.mapper.dart
+++ b/packages/dart_mappable/test/equality/function_fields_test.mapper.dart
@@ -28,6 +28,9 @@ class ExampleMapper extends ClassMapperBase<Example> {
     'functionField',
     _$functionField,
     arg: _arg$functionField,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/external_types/external_types_test.mapper.dart
+++ b/packages/dart_mappable/test/external_types/external_types_test.mapper.dart
@@ -26,6 +26,9 @@ class PersonMapper extends ClassMapperBase<Person> {
     'firstName',
     _$firstName,
     key: r'first_name',
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -118,7 +121,13 @@ class CakeMapper extends ClassMapperBase<f.Cake> {
   final String id = 'Cake';
 
   static String _$type(f.Cake v) => v.type;
-  static const Field<f.Cake, String> _f$type = Field('type', _$type);
+  static const Field<f.Cake, String> _f$type = Field(
+    'type',
+    _$type,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<f.Cake> fields = const {#type: _f$type};
@@ -199,6 +208,9 @@ class Person2Mapper extends ClassMapperBase<m.Person> {
     'firstName',
     _$firstName,
     key: r'first_name',
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -281,7 +293,13 @@ class AnimalMapper extends ClassMapperBase<o.Animal> {
   final String id = 'Animal';
 
   static String _$color(o.Animal v) => v.color;
-  static const Field<o.Animal, String> _f$color = Field('color', _$color);
+  static const Field<o.Animal, String> _f$color = Field(
+    'color',
+    _$color,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<o.Animal> fields = const {#color: _f$color};
@@ -339,9 +357,21 @@ class PetMapper extends SubClassMapperBase<o.Pet> {
   final String id = 'Pet';
 
   static m.Person _$owner(o.Pet v) => v.owner;
-  static const Field<o.Pet, m.Person> _f$owner = Field('owner', _$owner);
+  static const Field<o.Pet, m.Person> _f$owner = Field(
+    'owner',
+    _$owner,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$color(o.Pet v) => v.color;
-  static const Field<o.Pet, String> _f$color = Field('color', _$color);
+  static const Field<o.Pet, String> _f$color = Field(
+    'color',
+    _$color,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<o.Pet> fields = const {

--- a/packages/dart_mappable/test/external_types/unknown_interface.mapper.dart
+++ b/packages/dart_mappable/test/external_types/unknown_interface.mapper.dart
@@ -69,6 +69,9 @@ class DSOpacityDataMapper extends ClassMapperBase<DSOpacityData> {
     _$data,
     opt: true,
     def: const {HOpacity.bzOpacityIntense: 0.4},
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static double _$fallback(DSOpacityData v) => v.fallback;
   static const Field<DSOpacityData, double> _f$fallback = Field(
@@ -76,6 +79,9 @@ class DSOpacityDataMapper extends ClassMapperBase<DSOpacityData> {
     _$fallback,
     opt: true,
     def: 0.0,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/generics/duplicate_names_test.mapper.dart
+++ b/packages/dart_mappable/test/generics/duplicate_names_test.mapper.dart
@@ -26,13 +26,22 @@ class BoxMapper extends ClassMapperBase<Box> {
       <T extends Content>(f) => f<Box<T>>();
 
   static int _$size(Box v) => v.size;
-  static const Field<Box, int> _f$size = Field('size', _$size);
+  static const Field<Box, int> _f$size = Field(
+    'size',
+    _$size,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Content _$contents(Box v) => v.contents;
   static dynamic _arg$contents<T extends Content>(f) => f<T>();
   static const Field<Box, Content> _f$contents = Field(
     'contents',
     _$contents,
     arg: _arg$contents,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -140,7 +149,13 @@ class ContentMapper extends ClassMapperBase<Content> {
   final String id = 'Content';
 
   static String _$data(Content v) => v.data;
-  static const Field<Content, String> _f$data = Field('data', _$data);
+  static const Field<Content, String> _f$data = Field(
+    'data',
+    _$data,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Content> fields = const {#data: _f$data};

--- a/packages/dart_mappable/test/generics/generics_test.mapper.dart
+++ b/packages/dart_mappable/test/generics/generics_test.mapper.dart
@@ -26,13 +26,22 @@ class BoxMapper extends ClassMapperBase<Box> {
       <T extends Content>(f) => f<Box<T>>();
 
   static int _$size(Box v) => v.size;
-  static const Field<Box, int> _f$size = Field('size', _$size);
+  static const Field<Box, int> _f$size = Field(
+    'size',
+    _$size,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static List<Content> _$contents(Box v) => v.contents;
   static dynamic _arg$contents<T extends Content>(f) => f<List<T>>();
   static const Field<Box, List<Content>> _f$contents = Field(
     'contents',
     _$contents,
     arg: _arg$contents,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -245,7 +254,13 @@ class ConfettiMapper extends ClassMapperBase<Confetti> {
   final String id = 'Confetti';
 
   static String _$color(Confetti v) => v.color;
-  static const Field<Confetti, String> _f$color = Field('color', _$color);
+  static const Field<Confetti, String> _f$color = Field(
+    'color',
+    _$color,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Confetti> fields = const {#color: _f$color};
@@ -352,7 +367,13 @@ class DataMapper extends ClassMapperBase<Data> {
   final String id = 'Data';
 
   static String _$data(Data v) => v.data;
-  static const Field<Data, String> _f$data = Field('data', _$data);
+  static const Field<Data, String> _f$data = Field(
+    'data',
+    _$data,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Data> fields = const {#data: _f$data};
@@ -452,6 +473,9 @@ class SingleSettingMapper extends ClassMapperBase<SingleSetting> {
     _$properties,
     opt: true,
     arg: _arg$properties,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -582,7 +606,14 @@ class SettingsMapper extends ClassMapperBase<Settings> {
   static Map<String, SingleSetting<dynamic>>? _$settings(Settings v) =>
       v.settings;
   static const Field<Settings, Map<String, SingleSetting<dynamic>>>
-  _f$settings = Field('settings', _$settings, opt: true);
+  _f$settings = Field(
+    'settings',
+    _$settings,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Settings> fields = const {#settings: _f$settings};
@@ -730,6 +761,9 @@ class AMapper extends ClassMapperBase<A> {
     'value',
     _$value,
     arg: _arg$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -822,7 +856,13 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static List<String> _$value(B v) => v.value;
-  static const Field<B, List<String>> _f$value = Field('value', _$value);
+  static const Field<B, List<String>> _f$value = Field(
+    'value',
+    _$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#value: _f$value};
@@ -931,6 +971,9 @@ class AssetMapper extends ClassMapperBase<Asset> {
     'data',
     _$data,
     arg: _arg$data,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -1042,6 +1085,9 @@ class NullableGenericsMapper extends ClassMapperBase<NullableGenerics> {
     'value',
     _$value,
     arg: _arg$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -1177,6 +1223,9 @@ class FunctionContainerMapper extends ClassMapperBase<FunctionContainer> {
     'genericFunction',
     _$genericFunction,
     arg: _arg$genericFunction,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/generics/recursive_generics_test.mapper.dart
+++ b/packages/dart_mappable/test/generics/recursive_generics_test.mapper.dart
@@ -35,6 +35,9 @@ class ComparableBoxMapper extends ClassMapperBase<ComparableBox> {
     'value',
     _$value,
     arg: _arg$value,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/hooks/hooks_test.mapper.dart
+++ b/packages/dart_mappable/test/hooks/hooks_test.mapper.dart
@@ -28,6 +28,9 @@ class GameMapper extends ClassMapperBase<Game> {
     'player',
     _$player,
     hook: ChainedHook([PlayerHook(), UnmappedPropertiesHook('unmappedProps')]),
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -125,7 +128,13 @@ class PlayerMapper extends ClassMapperBase<Player> {
   final String id = 'Player';
 
   static String _$id(Player v) => v.id;
-  static const Field<Player, String> _f$id = Field('id', _$id);
+  static const Field<Player, String> _f$id = Field(
+    'id',
+    _$id,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Player> fields = const {#id: _f$id};
@@ -225,6 +234,9 @@ class CardGameMapper extends ClassMapperBase<CardGame> {
       UnmappedPropertiesHook('unmappedProps'),
       game.CardPlayerHook(),
     ]),
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/hooks/string_hooks_test.mapper.dart
+++ b/packages/dart_mappable/test/hooks/string_hooks_test.mapper.dart
@@ -26,14 +26,27 @@ class AMapper extends ClassMapperBase<A> {
     'a',
     _$a,
     hook: UnescapeNewlinesHook(),
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static String? _$b(A v) => v.b;
-  static const Field<A, String> _f$b = Field('b', _$b, hook: EmptyToNullHook());
+  static const Field<A, String> _f$b = Field(
+    'b',
+    _$b,
+    hook: EmptyToNullHook(),
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Map<int, dynamic>? _$c(A v) => v.c;
   static const Field<A, Map<int, dynamic>> _f$c = Field(
     'c',
     _$c,
     hook: StringMapHook(),
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/hooks/unmapped_props_hook_test.mapper.dart
+++ b/packages/dart_mappable/test/hooks/unmapped_props_hook_test.mapper.dart
@@ -25,9 +25,18 @@ class AMapper extends ClassMapperBase<A> {
   static const Field<A, Map<String, dynamic>> _f$unmappedProps = Field(
     'unmappedProps',
     _$unmappedProps,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static String? _$a(A v) => v.a;
-  static const Field<A, String> _f$a = Field('a', _$a);
+  static const Field<A, String> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {

--- a/packages/dart_mappable/test/initializer/init_package_test.init.dart
+++ b/packages/dart_mappable/test/initializer/init_package_test.init.dart
@@ -40,9 +40,10 @@ import '../selective_generation/selective_generation_test.dart' as p34;
 import '../serialization/basic_serialization_test.dart' as p35;
 import '../serialization/desync_serialization_test.dart' as p36;
 import '../serialization/encoding_params_test.dart' as p37;
-import '../serialization/nested_serialization_test.dart' as p38;
-import '../serialization/param_rewrite_test.dart' as p39;
-import '../serialization/with_getters_test.dart' as p40;
+import '../serialization/field_ignoring_test.dart' as p38;
+import '../serialization/nested_serialization_test.dart' as p39;
+import '../serialization/param_rewrite_test.dart' as p40;
+import '../serialization/with_getters_test.dart' as p41;
 import 'init_lib_test.dart' as p25;
 import 'models/model.dart' as p26;
 
@@ -189,12 +190,15 @@ void initializeMappers() {
   p36.CMapper.ensureInitialized();
   p37.AMapper.ensureInitialized();
   p37.BMapper.ensureInitialized();
-  p38.PersonMapper.ensureInitialized();
-  p38.CarMapper.ensureInitialized();
-  p38.BrandMapper.ensureInitialized();
-  p39.AMapper.ensureInitialized();
-  p39.BMapper.ensureInitialized();
-  p39.CMapper.ensureInitialized();
-  p40.ClassWithGettersMapper.ensureInitialized();
+  p38.UserMapper.ensureInitialized();
+  p38.UserWithIgnoreNullMapper.ensureInitialized();
+  p38.MixedFieldModesMapper.ensureInitialized();
+  p39.PersonMapper.ensureInitialized();
+  p39.CarMapper.ensureInitialized();
+  p39.BrandMapper.ensureInitialized();
+  p40.AMapper.ensureInitialized();
+  p40.BMapper.ensureInitialized();
+  p40.CMapper.ensureInitialized();
+  p41.ClassWithGettersMapper.ensureInitialized();
 }
 

--- a/packages/dart_mappable/test/polymorphism/mixed_mappable_test.mapper.dart
+++ b/packages/dart_mappable/test/polymorphism/mixed_mappable_test.mapper.dart
@@ -23,13 +23,28 @@ class BaseMapper extends ClassMapperBase<Base> {
   final String id = 'Base';
 
   static String _$id(Base v) => v.id;
-  static const Field<Base, String> _f$id = Field('id', _$id);
+  static const Field<Base, String> _f$id = Field(
+    'id',
+    _$id,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$name(Base v) => v.name;
-  static const Field<Base, String> _f$name = Field('name', _$name);
+  static const Field<Base, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Map<String, dynamic> _$objects(Base v) => v.objects;
   static const Field<Base, Map<String, dynamic>> _f$objects = Field(
     'objects',
     _$objects,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -85,13 +100,28 @@ class OneMapper extends ClassMapperBase<One> {
   final String id = 'One';
 
   static String _$id(One v) => v.id;
-  static const Field<One, String> _f$id = Field('id', _$id);
+  static const Field<One, String> _f$id = Field(
+    'id',
+    _$id,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$name(One v) => v.name;
-  static const Field<One, String> _f$name = Field('name', _$name);
+  static const Field<One, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Map<String, dynamic> _$objects(One v) => v.objects;
   static const Field<One, Map<String, dynamic>> _f$objects = Field(
     'objects',
     _$objects,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -211,7 +241,13 @@ class TwoMapper extends ClassMapperBase<Two> {
   final String id = 'Two';
 
   static String _$id(Two v) => v.id;
-  static const Field<Two, String> _f$id = Field('id', _$id);
+  static const Field<Two, String> _f$id = Field(
+    'id',
+    _$id,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Two> fields = const {#id: _f$id};

--- a/packages/dart_mappable/test/polymorphism/multi_poly_test.mapper.dart
+++ b/packages/dart_mappable/test/polymorphism/multi_poly_test.mapper.dart
@@ -23,7 +23,13 @@ class ShepherdMapper extends SubClassMapperBase<Shepherd> {
   final String id = 'Shepherd';
 
   static String? _$name(Shepherd v) => v.name;
-  static const Field<Shepherd, String> _f$name = Field('name', _$name);
+  static const Field<Shepherd, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Shepherd> fields = const {#name: _f$name};
@@ -141,7 +147,13 @@ class DogMapper extends SubClassMapperBase<Dog> {
   final String id = 'Dog';
 
   static String? _$name(Dog v) => v.name;
-  static const Field<Dog, String> _f$name = Field('name', _$name);
+  static const Field<Dog, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Dog> fields = const {#name: _f$name};
@@ -244,7 +256,13 @@ class AnimalMapper extends ClassMapperBase<Animal> {
   final String id = 'Animal';
 
   static String? _$name(Animal v) => v.name;
-  static const Field<Animal, String> _f$name = Field('name', _$name);
+  static const Field<Animal, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Animal> fields = const {#name: _f$name};
@@ -300,7 +318,13 @@ class CatMapper extends SubClassMapperBase<Cat> {
   final String id = 'Cat';
 
   static String? _$name(Cat v) => v.name;
-  static const Field<Cat, String> _f$name = Field('name', _$name);
+  static const Field<Cat, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Cat> fields = const {#name: _f$name};
@@ -363,7 +387,13 @@ class SiameseMapper extends SubClassMapperBase<Siamese> {
   final String id = 'Siamese';
 
   static String? _$name(Siamese v) => v.name;
-  static const Field<Siamese, String> _f$name = Field('name', _$name);
+  static const Field<Siamese, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Siamese> fields = const {#name: _f$name};
@@ -478,7 +508,13 @@ class HumanMapper extends ClassMapperBase<Human> {
   final String id = 'Human';
 
   static Cat _$cat(Human v) => v.cat;
-  static const Field<Human, Cat> _f$cat = Field('cat', _$cat);
+  static const Field<Human, Cat> _f$cat = Field(
+    'cat',
+    _$cat,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Human> fields = const {#cat: _f$cat};

--- a/packages/dart_mappable/test/polymorphism/polymorphism_test.mapper.dart
+++ b/packages/dart_mappable/test/polymorphism/polymorphism_test.mapper.dart
@@ -26,7 +26,13 @@ class AnimalMapper extends ClassMapperBase<Animal> {
   final String id = 'Animal';
 
   static String _$name(Animal v) => v.name;
-  static const Field<Animal, String> _f$name = Field('name', _$name);
+  static const Field<Animal, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Animal> fields = const {#name: _f$name};
@@ -79,9 +85,21 @@ class CatMapper extends SubClassMapperBase<Cat> {
   final String id = 'Cat';
 
   static String _$name(Cat v) => v.name;
-  static const Field<Cat, String> _f$name = Field('name', _$name);
+  static const Field<Cat, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$color(Cat v) => v.color;
-  static const Field<Cat, String> _f$color = Field('color', _$color);
+  static const Field<Cat, String> _f$color = Field(
+    'color',
+    _$color,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Cat> fields = const {#name: _f$name, #color: _f$color};
@@ -186,12 +204,21 @@ class DogMapper extends SubClassMapperBase<Dog> {
   final String id = 'Dog';
 
   static int _$age(Dog v) => v.age;
-  static const Field<Dog, int> _f$age = Field('age', _$age);
+  static const Field<Dog, int> _f$age = Field(
+    'age',
+    _$age,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$name(Dog v) => v.name;
   static const Field<Dog, String> _f$name = Field(
     'name',
     _$name,
     mode: FieldMode.member,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -292,7 +319,13 @@ class NullAnimalMapper extends SubClassMapperBase<NullAnimal> {
   final String id = 'NullAnimal';
 
   static String _$name(NullAnimal v) => v.name;
-  static const Field<NullAnimal, String> _f$name = Field('name', _$name);
+  static const Field<NullAnimal, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<NullAnimal> fields = const {#name: _f$name};
@@ -410,9 +443,21 @@ class DefaultAnimalMapper extends SubClassMapperBase<DefaultAnimal> {
   final String id = 'DefaultAnimal';
 
   static String _$name(DefaultAnimal v) => v.name;
-  static const Field<DefaultAnimal, String> _f$name = Field('name', _$name);
+  static const Field<DefaultAnimal, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$type(DefaultAnimal v) => v.type;
-  static const Field<DefaultAnimal, String> _f$type = Field('type', _$type);
+  static const Field<DefaultAnimal, String> _f$type = Field(
+    'type',
+    _$type,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<DefaultAnimal> fields = const {
@@ -541,16 +586,28 @@ class ZooMapper extends ClassMapperBase<Zoo> {
   final String id = 'Zoo';
 
   static Animal? _$animal(Zoo v) => v.animal;
-  static const Field<Zoo, Animal> _f$animal = Field('animal', _$animal);
+  static const Field<Zoo, Animal> _f$animal = Field(
+    'animal',
+    _$animal,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static List<Animal>? _$animals(Zoo v) => v.animals;
   static const Field<Zoo, List<Animal>> _f$animals = Field(
     'animals',
     _$animals,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static Map<String, Animal>? _$animalsMap(Zoo v) => v.animalsMap;
   static const Field<Zoo, Map<String, Animal>> _f$animalsMap = Field(
     'animalsMap',
     _$animalsMap,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/primitives/primitives_test.mapper.dart
+++ b/packages/dart_mappable/test/primitives/primitives_test.mapper.dart
@@ -23,11 +23,20 @@ class ItemsMapper extends ClassMapperBase<Items> {
   final String id = 'Items';
 
   static List<Item> _$items(Items v) => v.items;
-  static const Field<Items, List<Item>> _f$items = Field('items', _$items);
+  static const Field<Items, List<Item>> _f$items = Field(
+    'items',
+    _$items,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Map<int, Item> _$items2(Items v) => v.items2;
   static const Field<Items, Map<int, Item>> _f$items2 = Field(
     'items2',
     _$items2,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override
@@ -145,7 +154,13 @@ class ItemMapper extends ClassMapperBase<Item> {
   final String id = 'Item';
 
   static int _$index(Item v) => v.index;
-  static const Field<Item, int> _f$index = Field('index', _$index);
+  static const Field<Item, int> _f$index = Field(
+    'index',
+    _$index,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Item> fields = const {#index: _f$index};

--- a/packages/dart_mappable/test/records/mappable_record_test.mapper.dart
+++ b/packages/dart_mappable/test/records/mappable_record_test.mapper.dart
@@ -24,11 +24,20 @@ class LocationMapper extends ClassMapperBase<Location> {
   final String id = 'Location';
 
   static Point _$point(Location v) => v.point;
-  static const Field<Location, Point> _f$point = Field('point', _$point);
+  static const Field<Location, Point> _f$point = Field(
+    'point',
+    _$point,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Offset<dynamic> _$offset(Location v) => v.offset;
   static const Field<Location, Offset<dynamic>> _f$offset = Field(
     'offset',
     _$offset,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/records/record_model_test.mapper.dart
+++ b/packages/dart_mappable/test/records/record_model_test.mapper.dart
@@ -28,11 +28,24 @@ class AMapper extends ClassMapperBase<A> {
       <T>(f) => f<A<T>>();
 
   static String _$a(A v) => v.a;
-  static const Field<A, String> _f$a = Field('a', _$a);
+  static const Field<A, String> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static _t$_R0<int, dynamic, C, _t$_R1<double, double>> _$r(A v) => v.r;
   static dynamic _arg$r<T>(f) => f<_t$_R0<int, T, C, _t$_R1<double, double>>>();
   static const Field<A, _t$_R0<int, dynamic, C, _t$_R1<double, double>>> _f$r =
-      Field('r', _$r, arg: _arg$r);
+      Field(
+        'r',
+        _$r,
+        arg: _arg$r,
+        includeFromJson: true,
+        includeToJson: true,
+        includeIfNull: false,
+      );
 
   @override
   final MappableFields<A> fields = const {#a: _f$a, #r: _f$r};
@@ -125,9 +138,21 @@ class CMapper extends ClassMapperBase<C> {
   final String id = 'C';
 
   static String _$c(C v) => v.c;
-  static const Field<C, String> _f$c = Field('c', _$c);
+  static const Field<C, String> _f$c = Field(
+    'c',
+    _$c,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static _t$_R1<String, int> _$d(C v) => v.d;
-  static const Field<C, _t$_R1<String, int>> _f$d = Field('d', _$d);
+  static const Field<C, _t$_R1<String, int>> _f$d = Field(
+    'd',
+    _$d,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<C> fields = const {#c: _f$c, #d: _f$d};

--- a/packages/dart_mappable/test/selective_generation/selective_generation_test.mapper.dart
+++ b/packages/dart_mappable/test/selective_generation/selective_generation_test.mapper.dart
@@ -22,7 +22,13 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static String _$a(A v) => v.a;
-  static const Field<A, String> _f$a = Field('a', _$a);
+  static const Field<A, String> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#a: _f$a};
@@ -90,7 +96,13 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static String _$b(B v) => v.b;
-  static const Field<B, String> _f$b = Field('b', _$b);
+  static const Field<B, String> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#b: _f$b};

--- a/packages/dart_mappable/test/serialization/basic_serialization_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/basic_serialization_test.mapper.dart
@@ -73,15 +73,49 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static String _$a(A v) => v.a;
-  static const Field<A, String> _f$a = Field('a', _$a);
+  static const Field<A, String> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$b(A v) => v.b;
-  static const Field<A, int> _f$b = Field('b', _$b, opt: true, def: 0);
+  static const Field<A, int> _f$b = Field(
+    'b',
+    _$b,
+    opt: true,
+    def: 0,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static double? _$c(A v) => v.c;
-  static const Field<A, double> _f$c = Field('c', _$c, opt: true);
+  static const Field<A, double> _f$c = Field(
+    'c',
+    _$c,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static bool _$d(A v) => v.d;
-  static const Field<A, bool> _f$d = Field('d', _$d);
+  static const Field<A, bool> _f$d = Field(
+    'd',
+    _$d,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static B? _$e(A v) => v.e;
-  static const Field<A, B> _f$e = Field('e', _$e, opt: true);
+  static const Field<A, B> _f$e = Field(
+    'e',
+    _$e,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {

--- a/packages/dart_mappable/test/serialization/desync_serialization_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/desync_serialization_test.mapper.dart
@@ -24,11 +24,29 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static int _$a(A v) => v.a;
-  static const Field<A, int> _f$a = Field('a', _$a);
+  static const Field<A, int> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$b(A v) => v.b;
-  static const Field<A, int> _f$b = Field('b', _$b);
+  static const Field<A, int> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static C _$c(A v) => v.c;
-  static const Field<A, C> _f$c = Field('c', _$c);
+  static const Field<A, C> _f$c = Field(
+    'c',
+    _$c,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#a: _f$a, #b: _f$b, #c: _f$c};
@@ -122,7 +140,13 @@ class CMapper extends ClassMapperBase<C> {
   final String id = 'C';
 
   static int _$x(C v) => v.x;
-  static const Field<C, int> _f$x = Field('x', _$x);
+  static const Field<C, int> _f$x = Field(
+    'x',
+    _$x,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<C> fields = const {#x: _f$x};
@@ -213,13 +237,37 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static int _$a(B v) => v.a;
-  static const Field<B, int> _f$a = Field('a', _$a);
+  static const Field<B, int> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$d(B v) => v.d;
-  static const Field<B, int> _f$d = Field('d', _$d);
+  static const Field<B, int> _f$d = Field(
+    'd',
+    _$d,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$b(B v) => v.b;
-  static const Field<B, int> _f$b = Field('b', _$b);
+  static const Field<B, int> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static C _$c(B v) => v.c;
-  static const Field<B, C> _f$c = Field('c', _$c);
+  static const Field<B, C> _f$c = Field(
+    'c',
+    _$c,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {

--- a/packages/dart_mappable/test/serialization/encoding_params_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/encoding_params_test.mapper.dart
@@ -73,9 +73,22 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static String _$a(A v) => v.a;
-  static const Field<A, String> _f$a = Field('a', _$a);
+  static const Field<A, String> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static B? _$b(A v) => v.b;
-  static const Field<A, B> _f$b = Field('b', _$b, opt: true);
+  static const Field<A, B> _f$b = Field(
+    'b',
+    _$b,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#a: _f$a, #b: _f$b};

--- a/packages/dart_mappable/test/serialization/field_ignoring_test.dart
+++ b/packages/dart_mappable/test/serialization/field_ignoring_test.dart
@@ -1,0 +1,168 @@
+import 'dart:convert';
+
+import 'package:dart_mappable/dart_mappable.dart';
+import 'package:test/test.dart';
+
+part 'field_ignoring_test.mapper.dart';
+
+@MappableClass()
+class User with UserMappable {
+  String name;
+  String email;
+
+  @MappableField(includeToJson: false)
+  String? passwordValue;
+
+  @MappableField(includeFromJson: false)
+  DateTime? lastLoginValue;
+
+  @MappableField(includeIfNull: true)
+  String? secretFieldValue;
+
+  User(this.name, this.email, this.passwordValue, this.lastLoginValue);
+}
+
+@MappableClass(ignoreNull: true)
+class UserWithIgnoreNull with UserWithIgnoreNullMappable {
+  String name;
+
+  @MappableField(includeIfNull: true)
+  String? emailValue;
+
+  @MappableField(includeToJson: false)
+  String? passwordValue;
+
+  UserWithIgnoreNull(this.name, this.emailValue, this.passwordValue);
+}
+
+@MappableClass()
+class MixedFieldModes with MixedFieldModesMappable {
+  String name;
+
+  @MappableField(includeIfNull: true)
+  String? computedFieldValue;
+
+  @MappableField(includeToJson: false, includeFromJson: false)
+  String? ignoredFieldValue;
+
+  MixedFieldModes(this.name, this.computedFieldValue, this.ignoredFieldValue);
+}
+
+void main() {
+  group('Field Ignoring', () {
+    test('includeToJson: false excludes field from serialization', () {
+      var user = User('John', 'john@example.com', 'secret123', DateTime.now());
+
+      var map = user.toMap();
+      expect(map.containsKey('passwordValue'), isFalse);
+      expect(map.containsKey('name'), isTrue);
+      expect(map.containsKey('email'), isTrue);
+    });
+
+    test('includeFromJson: false excludes field from deserialization', () {
+      var map = {
+        'name': 'John',
+        'email': 'john@example.com',
+        'passwordValue': 'secret123',
+        'lastLoginValue': '2023-01-01T00:00:00.000Z',
+      };
+
+      var user = UserMapper.fromMap(map);
+      expect(user.name, equals('John'));
+      expect(user.email, equals('john@example.com'));
+      expect(user.passwordValue, equals('secret123'));
+      expect(
+        user.lastLoginValue,
+        isNull,
+      ); // Should be ignored during deserialization
+    });
+
+    test('includeIfNull: true includes null values in serialization', () {
+      var user = User('John', 'john@example.com', null, null);
+
+      var map = user.toMap();
+      expect(map.containsKey('secretFieldValue'), isTrue);
+      expect(map['secretFieldValue'], isNull);
+    });
+
+    test('includeIfNull overrides class-level ignoreNull', () {
+      var user = UserWithIgnoreNull('John', null, 'secret123');
+
+      var map = user.toMap();
+      // emailValue should be included because includeIfNull: true
+      expect(map.containsKey('emailValue'), isTrue);
+      expect(map['emailValue'], isNull);
+      // passwordValue should be excluded because includeToJson: false
+      expect(map.containsKey('passwordValue'), isFalse);
+    });
+
+    test('field with both includeToJson: false and includeFromJson: false', () {
+      var mixed = MixedFieldModes('John', null, 'should be ignored');
+
+      // Should not appear in serialization
+      var map = mixed.toMap();
+      expect(map.containsKey('ignoredFieldValue'), isFalse);
+
+      // Should not be set during deserialization
+      var mapWithIgnored = {
+        'name': 'Jane',
+        'ignoredFieldValue': 'should be ignored',
+        'computedFieldValue': 'computed value',
+      };
+
+      var decoded = MixedFieldModesMapper.fromMap(mapWithIgnored);
+      expect(decoded.name, equals('Jane'));
+      expect(decoded.ignoredFieldValue, isNull);
+      expect(decoded.computedFieldValue, equals('computed value'));
+    });
+
+    test(
+      'backward compatibility - fields without annotations work as before',
+      () {
+        var user = User(
+          'John',
+          'john@example.com',
+          'secret123',
+          DateTime.now(),
+        );
+
+        var map = user.toMap();
+        expect(map.containsKey('name'), isTrue);
+        expect(map.containsKey('email'), isTrue);
+        expect(map['name'], equals('John'));
+        expect(map['email'], equals('john@example.com'));
+      },
+    );
+
+    test('JSON serialization respects field ignoring', () {
+      var user = User('John', 'john@example.com', 'secret123', DateTime.now());
+
+      var json = user.toJson();
+      var decodedMap = jsonDecode(json);
+
+      expect(decodedMap.containsKey('passwordValue'), isFalse);
+      expect(decodedMap.containsKey('name'), isTrue);
+      expect(decodedMap['name'], equals('John'));
+    });
+
+    test('JSON deserialization respects field ignoring', () {
+      var json =
+          '{"name": "John", "email": "john@example.com", "passwordValue": "secret123", "lastLoginValue": "2023-01-01T00:00:00.000Z"}';
+
+      var user = UserMapper.fromJson(json);
+      expect(user.name, equals('John'));
+      expect(user.email, equals('john@example.com'));
+      expect(user.passwordValue, equals('secret123'));
+      expect(user.lastLoginValue, isNull); // Should be ignored
+    });
+
+    test('copyWith respects field ignoring for serialization', () {
+      var user = User('John', 'john@example.com', 'secret123', DateTime.now());
+      var copied = user.copyWith(name: 'Jane');
+
+      var map = copied.toMap();
+      expect(map.containsKey('passwordValue'), isFalse);
+      expect(map['name'], equals('Jane'));
+    });
+  });
+}

--- a/packages/dart_mappable/test/serialization/field_ignoring_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/field_ignoring_test.mapper.dart
@@ -22,25 +22,43 @@ class UserMapper extends ClassMapperBase<User> {
   final String id = 'User';
 
   static String _$name(User v) => v.name;
-  static const Field<User, String> _f$name = Field('name', _$name);
+  static const Field<User, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$email(User v) => v.email;
-  static const Field<User, String> _f$email = Field('email', _$email);
+  static const Field<User, String> _f$email = Field(
+    'email',
+    _$email,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String? _$passwordValue(User v) => v.passwordValue;
   static const Field<User, String> _f$passwordValue = Field(
     'passwordValue',
     _$passwordValue,
+    includeFromJson: true,
     includeToJson: false,
+    includeIfNull: false,
   );
   static DateTime? _$lastLoginValue(User v) => v.lastLoginValue;
   static const Field<User, DateTime> _f$lastLoginValue = Field(
     'lastLoginValue',
     _$lastLoginValue,
     includeFromJson: false,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static String? _$secretFieldValue(User v) => v.secretFieldValue;
   static const Field<User, String> _f$secretFieldValue = Field(
     'secretFieldValue',
     _$secretFieldValue,
+    includeFromJson: true,
+    includeToJson: true,
     includeIfNull: true,
   );
 
@@ -168,18 +186,25 @@ class UserWithIgnoreNullMapper extends ClassMapperBase<UserWithIgnoreNull> {
   static const Field<UserWithIgnoreNull, String> _f$name = Field(
     'name',
     _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static String? _$emailValue(UserWithIgnoreNull v) => v.emailValue;
   static const Field<UserWithIgnoreNull, String> _f$emailValue = Field(
     'emailValue',
     _$emailValue,
+    includeFromJson: true,
+    includeToJson: true,
     includeIfNull: true,
   );
   static String? _$passwordValue(UserWithIgnoreNull v) => v.passwordValue;
   static const Field<UserWithIgnoreNull, String> _f$passwordValue = Field(
     'passwordValue',
     _$passwordValue,
+    includeFromJson: true,
     includeToJson: false,
+    includeIfNull: false,
   );
 
   @override
@@ -324,12 +349,20 @@ class MixedFieldModesMapper extends ClassMapperBase<MixedFieldModes> {
   final String id = 'MixedFieldModes';
 
   static String _$name(MixedFieldModes v) => v.name;
-  static const Field<MixedFieldModes, String> _f$name = Field('name', _$name);
+  static const Field<MixedFieldModes, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String? _$computedFieldValue(MixedFieldModes v) =>
       v.computedFieldValue;
   static const Field<MixedFieldModes, String> _f$computedFieldValue = Field(
     'computedFieldValue',
     _$computedFieldValue,
+    includeFromJson: true,
+    includeToJson: true,
     includeIfNull: true,
   );
   static String? _$ignoredFieldValue(MixedFieldModes v) => v.ignoredFieldValue;
@@ -338,6 +371,7 @@ class MixedFieldModesMapper extends ClassMapperBase<MixedFieldModes> {
     _$ignoredFieldValue,
     includeFromJson: false,
     includeToJson: false,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/serialization/field_ignoring_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/field_ignoring_test.mapper.dart
@@ -1,0 +1,462 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'field_ignoring_test.dart';
+
+class UserMapper extends ClassMapperBase<User> {
+  UserMapper._();
+
+  static UserMapper? _instance;
+  static UserMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = UserMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'User';
+
+  static String _$name(User v) => v.name;
+  static const Field<User, String> _f$name = Field('name', _$name);
+  static String _$email(User v) => v.email;
+  static const Field<User, String> _f$email = Field('email', _$email);
+  static String? _$passwordValue(User v) => v.passwordValue;
+  static const Field<User, String> _f$passwordValue = Field(
+    'passwordValue',
+    _$passwordValue,
+    includeToJson: false,
+  );
+  static DateTime? _$lastLoginValue(User v) => v.lastLoginValue;
+  static const Field<User, DateTime> _f$lastLoginValue = Field(
+    'lastLoginValue',
+    _$lastLoginValue,
+    includeFromJson: false,
+  );
+  static String? _$secretFieldValue(User v) => v.secretFieldValue;
+  static const Field<User, String> _f$secretFieldValue = Field(
+    'secretFieldValue',
+    _$secretFieldValue,
+    includeIfNull: true,
+  );
+
+  @override
+  final MappableFields<User> fields = const {
+    #name: _f$name,
+    #email: _f$email,
+    #passwordValue: _f$passwordValue,
+    #lastLoginValue: _f$lastLoginValue,
+    #secretFieldValue: _f$secretFieldValue,
+  };
+
+  static User _instantiate(DecodingData data) {
+    return User(
+      data.dec(_f$name),
+      data.dec(_f$email),
+      data.dec(_f$passwordValue),
+      null,
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static User fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<User>(map);
+  }
+
+  static User fromJson(String json) {
+    return ensureInitialized().decodeJson<User>(json);
+  }
+}
+
+mixin UserMappable {
+  String toJson() {
+    return UserMapper.ensureInitialized().encodeJson<User>(this as User);
+  }
+
+  Map<String, dynamic> toMap() {
+    return UserMapper.ensureInitialized().encodeMap<User>(this as User);
+  }
+
+  UserCopyWith<User, User, User> get copyWith =>
+      _UserCopyWithImpl<User, User>(this as User, $identity, $identity);
+  @override
+  String toString() {
+    return UserMapper.ensureInitialized().stringifyValue(this as User);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return UserMapper.ensureInitialized().equalsValue(this as User, other);
+  }
+
+  @override
+  int get hashCode {
+    return UserMapper.ensureInitialized().hashValue(this as User);
+  }
+}
+
+extension UserValueCopy<$R, $Out> on ObjectCopyWith<$R, User, $Out> {
+  UserCopyWith<$R, User, $Out> get $asUser =>
+      $base.as((v, t, t2) => _UserCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class UserCopyWith<$R, $In extends User, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({
+    String? name,
+    String? email,
+    String? passwordValue,
+    DateTime? lastLoginValue,
+  });
+  UserCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _UserCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, User, $Out>
+    implements UserCopyWith<$R, User, $Out> {
+  _UserCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<User> $mapper = UserMapper.ensureInitialized();
+  @override
+  $R call({
+    String? name,
+    String? email,
+    Object? passwordValue = $none,
+    Object? lastLoginValue = $none,
+  }) => $apply(
+    FieldCopyWithData({
+      if (name != null) #name: name,
+      if (email != null) #email: email,
+      if (passwordValue != $none) #passwordValue: passwordValue,
+      if (lastLoginValue != $none) #lastLoginValue: lastLoginValue,
+    }),
+  );
+  @override
+  User $make(CopyWithData data) => User(
+    data.get(#name, or: $value.name),
+    data.get(#email, or: $value.email),
+    data.get(#passwordValue, or: $value.passwordValue),
+    data.get(#lastLoginValue, or: $value.lastLoginValue),
+  );
+
+  @override
+  UserCopyWith<$R2, User, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _UserCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class UserWithIgnoreNullMapper extends ClassMapperBase<UserWithIgnoreNull> {
+  UserWithIgnoreNullMapper._();
+
+  static UserWithIgnoreNullMapper? _instance;
+  static UserWithIgnoreNullMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = UserWithIgnoreNullMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'UserWithIgnoreNull';
+
+  static String _$name(UserWithIgnoreNull v) => v.name;
+  static const Field<UserWithIgnoreNull, String> _f$name = Field(
+    'name',
+    _$name,
+  );
+  static String? _$emailValue(UserWithIgnoreNull v) => v.emailValue;
+  static const Field<UserWithIgnoreNull, String> _f$emailValue = Field(
+    'emailValue',
+    _$emailValue,
+    includeIfNull: true,
+  );
+  static String? _$passwordValue(UserWithIgnoreNull v) => v.passwordValue;
+  static const Field<UserWithIgnoreNull, String> _f$passwordValue = Field(
+    'passwordValue',
+    _$passwordValue,
+    includeToJson: false,
+  );
+
+  @override
+  final MappableFields<UserWithIgnoreNull> fields = const {
+    #name: _f$name,
+    #emailValue: _f$emailValue,
+    #passwordValue: _f$passwordValue,
+  };
+  @override
+  final bool ignoreNull = true;
+
+  static UserWithIgnoreNull _instantiate(DecodingData data) {
+    return UserWithIgnoreNull(
+      data.dec(_f$name),
+      data.dec(_f$emailValue),
+      data.dec(_f$passwordValue),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static UserWithIgnoreNull fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<UserWithIgnoreNull>(map);
+  }
+
+  static UserWithIgnoreNull fromJson(String json) {
+    return ensureInitialized().decodeJson<UserWithIgnoreNull>(json);
+  }
+}
+
+mixin UserWithIgnoreNullMappable {
+  String toJson() {
+    return UserWithIgnoreNullMapper.ensureInitialized()
+        .encodeJson<UserWithIgnoreNull>(this as UserWithIgnoreNull);
+  }
+
+  Map<String, dynamic> toMap() {
+    return UserWithIgnoreNullMapper.ensureInitialized()
+        .encodeMap<UserWithIgnoreNull>(this as UserWithIgnoreNull);
+  }
+
+  UserWithIgnoreNullCopyWith<
+    UserWithIgnoreNull,
+    UserWithIgnoreNull,
+    UserWithIgnoreNull
+  >
+  get copyWith =>
+      _UserWithIgnoreNullCopyWithImpl<UserWithIgnoreNull, UserWithIgnoreNull>(
+        this as UserWithIgnoreNull,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return UserWithIgnoreNullMapper.ensureInitialized().stringifyValue(
+      this as UserWithIgnoreNull,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return UserWithIgnoreNullMapper.ensureInitialized().equalsValue(
+      this as UserWithIgnoreNull,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return UserWithIgnoreNullMapper.ensureInitialized().hashValue(
+      this as UserWithIgnoreNull,
+    );
+  }
+}
+
+extension UserWithIgnoreNullValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, UserWithIgnoreNull, $Out> {
+  UserWithIgnoreNullCopyWith<$R, UserWithIgnoreNull, $Out>
+  get $asUserWithIgnoreNull => $base.as(
+    (v, t, t2) => _UserWithIgnoreNullCopyWithImpl<$R, $Out>(v, t, t2),
+  );
+}
+
+abstract class UserWithIgnoreNullCopyWith<
+  $R,
+  $In extends UserWithIgnoreNull,
+  $Out
+>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({String? name, String? emailValue, String? passwordValue});
+  UserWithIgnoreNullCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _UserWithIgnoreNullCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, UserWithIgnoreNull, $Out>
+    implements UserWithIgnoreNullCopyWith<$R, UserWithIgnoreNull, $Out> {
+  _UserWithIgnoreNullCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<UserWithIgnoreNull> $mapper =
+      UserWithIgnoreNullMapper.ensureInitialized();
+  @override
+  $R call({
+    String? name,
+    Object? emailValue = $none,
+    Object? passwordValue = $none,
+  }) => $apply(
+    FieldCopyWithData({
+      if (name != null) #name: name,
+      if (emailValue != $none) #emailValue: emailValue,
+      if (passwordValue != $none) #passwordValue: passwordValue,
+    }),
+  );
+  @override
+  UserWithIgnoreNull $make(CopyWithData data) => UserWithIgnoreNull(
+    data.get(#name, or: $value.name),
+    data.get(#emailValue, or: $value.emailValue),
+    data.get(#passwordValue, or: $value.passwordValue),
+  );
+
+  @override
+  UserWithIgnoreNullCopyWith<$R2, UserWithIgnoreNull, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _UserWithIgnoreNullCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class MixedFieldModesMapper extends ClassMapperBase<MixedFieldModes> {
+  MixedFieldModesMapper._();
+
+  static MixedFieldModesMapper? _instance;
+  static MixedFieldModesMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = MixedFieldModesMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'MixedFieldModes';
+
+  static String _$name(MixedFieldModes v) => v.name;
+  static const Field<MixedFieldModes, String> _f$name = Field('name', _$name);
+  static String? _$computedFieldValue(MixedFieldModes v) =>
+      v.computedFieldValue;
+  static const Field<MixedFieldModes, String> _f$computedFieldValue = Field(
+    'computedFieldValue',
+    _$computedFieldValue,
+    includeIfNull: true,
+  );
+  static String? _$ignoredFieldValue(MixedFieldModes v) => v.ignoredFieldValue;
+  static const Field<MixedFieldModes, String> _f$ignoredFieldValue = Field(
+    'ignoredFieldValue',
+    _$ignoredFieldValue,
+    includeFromJson: false,
+    includeToJson: false,
+  );
+
+  @override
+  final MappableFields<MixedFieldModes> fields = const {
+    #name: _f$name,
+    #computedFieldValue: _f$computedFieldValue,
+    #ignoredFieldValue: _f$ignoredFieldValue,
+  };
+
+  static MixedFieldModes _instantiate(DecodingData data) {
+    return MixedFieldModes(
+      data.dec(_f$name),
+      data.dec(_f$computedFieldValue),
+      null,
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static MixedFieldModes fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<MixedFieldModes>(map);
+  }
+
+  static MixedFieldModes fromJson(String json) {
+    return ensureInitialized().decodeJson<MixedFieldModes>(json);
+  }
+}
+
+mixin MixedFieldModesMappable {
+  String toJson() {
+    return MixedFieldModesMapper.ensureInitialized()
+        .encodeJson<MixedFieldModes>(this as MixedFieldModes);
+  }
+
+  Map<String, dynamic> toMap() {
+    return MixedFieldModesMapper.ensureInitialized().encodeMap<MixedFieldModes>(
+      this as MixedFieldModes,
+    );
+  }
+
+  MixedFieldModesCopyWith<MixedFieldModes, MixedFieldModes, MixedFieldModes>
+  get copyWith =>
+      _MixedFieldModesCopyWithImpl<MixedFieldModes, MixedFieldModes>(
+        this as MixedFieldModes,
+        $identity,
+        $identity,
+      );
+  @override
+  String toString() {
+    return MixedFieldModesMapper.ensureInitialized().stringifyValue(
+      this as MixedFieldModes,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return MixedFieldModesMapper.ensureInitialized().equalsValue(
+      this as MixedFieldModes,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return MixedFieldModesMapper.ensureInitialized().hashValue(
+      this as MixedFieldModes,
+    );
+  }
+}
+
+extension MixedFieldModesValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, MixedFieldModes, $Out> {
+  MixedFieldModesCopyWith<$R, MixedFieldModes, $Out> get $asMixedFieldModes =>
+      $base.as((v, t, t2) => _MixedFieldModesCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class MixedFieldModesCopyWith<$R, $In extends MixedFieldModes, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({
+    String? name,
+    String? computedFieldValue,
+    String? ignoredFieldValue,
+  });
+  MixedFieldModesCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _MixedFieldModesCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, MixedFieldModes, $Out>
+    implements MixedFieldModesCopyWith<$R, MixedFieldModes, $Out> {
+  _MixedFieldModesCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<MixedFieldModes> $mapper =
+      MixedFieldModesMapper.ensureInitialized();
+  @override
+  $R call({
+    String? name,
+    Object? computedFieldValue = $none,
+    Object? ignoredFieldValue = $none,
+  }) => $apply(
+    FieldCopyWithData({
+      if (name != null) #name: name,
+      if (computedFieldValue != $none) #computedFieldValue: computedFieldValue,
+      if (ignoredFieldValue != $none) #ignoredFieldValue: ignoredFieldValue,
+    }),
+  );
+  @override
+  MixedFieldModes $make(CopyWithData data) => MixedFieldModes(
+    data.get(#name, or: $value.name),
+    data.get(#computedFieldValue, or: $value.computedFieldValue),
+    data.get(#ignoredFieldValue, or: $value.ignoredFieldValue),
+  );
+
+  @override
+  MixedFieldModesCopyWith<$R2, MixedFieldModes, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _MixedFieldModesCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/packages/dart_mappable/test/serialization/nested_serialization_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/nested_serialization_test.mapper.dart
@@ -73,16 +73,32 @@ class PersonMapper extends ClassMapperBase<Person> {
   final String id = 'Person';
 
   static String _$name(Person v) => v.name;
-  static const Field<Person, String> _f$name = Field('name', _$name);
+  static const Field<Person, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$age(Person v) => v.age;
   static const Field<Person, int> _f$age = Field(
     'age',
     _$age,
     opt: true,
     def: 18,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
   static Car? _$car(Person v) => v.car;
-  static const Field<Person, Car> _f$car = Field('car', _$car, opt: true);
+  static const Field<Person, Car> _f$car = Field(
+    'car',
+    _$car,
+    opt: true,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<Person> fields = const {
@@ -195,14 +211,29 @@ class CarMapper extends ClassMapperBase<Car> {
   final String id = 'Car';
 
   static int _$drivenKm(Car v) => v.drivenKm;
-  static const Field<Car, int> _f$drivenKm = Field('drivenKm', _$drivenKm);
+  static const Field<Car, int> _f$drivenKm = Field(
+    'drivenKm',
+    _$drivenKm,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static Brand _$brand(Car v) => v.brand;
-  static const Field<Car, Brand> _f$brand = Field('brand', _$brand);
+  static const Field<Car, Brand> _f$brand = Field(
+    'brand',
+    _$brand,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static double _$miles(Car v) => v.miles;
   static const Field<Car, double> _f$miles = Field(
     'miles',
     _$miles,
     mode: FieldMode.member,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
   );
 
   @override

--- a/packages/dart_mappable/test/serialization/param_rewrite_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/param_rewrite_test.mapper.dart
@@ -22,11 +22,30 @@ class AMapper extends ClassMapperBase<A> {
   final String id = 'A';
 
   static int _$a(A v) => v.a;
-  static const Field<A, int> _f$a = Field('a', _$a);
+  static const Field<A, int> _f$a = Field(
+    'a',
+    _$a,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$b(A v) => v.b;
-  static const Field<A, int> _f$b = Field('b', _$b);
+  static const Field<A, int> _f$b = Field(
+    'b',
+    _$b,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$_c(A v) => v._c;
-  static const Field<A, int> _f$_c = Field('_c', _$_c, key: r'c');
+  static const Field<A, int> _f$_c = Field(
+    '_c',
+    _$_c,
+    key: r'c',
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<A> fields = const {#a: _f$a, #b: _f$b, #_c: _f$_c};
@@ -126,9 +145,23 @@ class BMapper extends ClassMapperBase<B> {
   final String id = 'B';
 
   static int _$b(B v) => v.b;
-  static const Field<B, int> _f$b = Field('b', _$b, key: r'a');
+  static const Field<B, int> _f$b = Field(
+    'b',
+    _$b,
+    key: r'a',
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$a(B v) => v.a;
-  static const Field<B, int> _f$a = Field('a', _$a, key: r'b');
+  static const Field<B, int> _f$a = Field(
+    'a',
+    _$a,
+    key: r'b',
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<B> fields = const {#b: _f$b, #a: _f$a};
@@ -220,9 +253,22 @@ class CMapper extends ClassMapperBase<C> {
   final String id = 'C';
 
   static String _$name(C v) => v.name;
-  static const Field<C, String> _f$name = Field('name', _$name);
+  static const Field<C, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static String _$data(C v) => v.data;
-  static const Field<C, String> _f$data = Field('data', _$data, key: r'd');
+  static const Field<C, String> _f$data = Field(
+    'data',
+    _$data,
+    key: r'd',
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<C> fields = const {#name: _f$name, #data: _f$data};

--- a/packages/dart_mappable/test/serialization/with_getters_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/with_getters_test.mapper.dart
@@ -22,9 +22,21 @@ class ClassWithGettersMapper extends ClassMapperBase<ClassWithGetters> {
   final String id = 'ClassWithGetters';
 
   static String _$name(ClassWithGetters v) => v.name;
-  static const Field<ClassWithGetters, String> _f$name = Field('name', _$name);
+  static const Field<ClassWithGetters, String> _f$name = Field(
+    'name',
+    _$name,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
   static int _$count(ClassWithGetters v) => v.count;
-  static const Field<ClassWithGetters, int> _f$count = Field('count', _$count);
+  static const Field<ClassWithGetters, int> _f$count = Field(
+    'count',
+    _$count,
+    includeFromJson: true,
+    includeToJson: true,
+    includeIfNull: false,
+  );
 
   @override
   final MappableFields<ClassWithGetters> fields = const {

--- a/packages/dart_mappable_builder/lib/src/elements/field/class_mapper_field_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/field/class_mapper_field_element.dart
@@ -153,7 +153,7 @@ class ClassMapperFieldElement extends MapperFieldElement {
         _getIncludeFromJson(field?.getter) ??
         _getIncludeFromJson(param?.parameter) ??
         true;
-    return includeFromJson ? '' : ', includeFromJson: false';
+    return ', includeFromJson: $includeFromJson';
   }();
 
   @override
@@ -163,7 +163,7 @@ class ClassMapperFieldElement extends MapperFieldElement {
         _getIncludeToJson(field?.getter) ??
         _getIncludeToJson(param?.parameter) ??
         true;
-    return includeToJson ? '' : ', includeToJson: false';
+    return ', includeToJson: $includeToJson';
   }();
 
   @override
@@ -173,7 +173,7 @@ class ClassMapperFieldElement extends MapperFieldElement {
         _getIncludeIfNull(field?.getter) ??
         _getIncludeIfNull(param?.parameter) ??
         false;
-    return includeIfNull ? ', includeIfNull: true' : '';
+    return ', includeIfNull: $includeIfNull';
   }();
 }
 

--- a/packages/dart_mappable_builder/lib/src/elements/field/class_mapper_field_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/field/class_mapper_field_element.dart
@@ -145,6 +145,36 @@ class ClassMapperFieldElement extends MapperFieldElement {
         (await hookFor(field?.getter));
     return hook != null ? ', hook: $hook' : '';
   }();
+
+  @override
+  late final String includeFromJson = () {
+    var includeFromJson =
+        _getIncludeFromJson(field) ??
+        _getIncludeFromJson(field?.getter) ??
+        _getIncludeFromJson(param?.parameter) ??
+        true;
+    return includeFromJson ? '' : ', includeFromJson: false';
+  }();
+
+  @override
+  late final String includeToJson = () {
+    var includeToJson =
+        _getIncludeToJson(field) ??
+        _getIncludeToJson(field?.getter) ??
+        _getIncludeToJson(param?.parameter) ??
+        true;
+    return includeToJson ? '' : ', includeToJson: false';
+  }();
+
+  @override
+  late final String includeIfNull = () {
+    var includeIfNull =
+        _getIncludeIfNull(field) ??
+        _getIncludeIfNull(field?.getter) ??
+        _getIncludeIfNull(param?.parameter) ??
+        false;
+    return includeIfNull ? ', includeIfNull: true' : '';
+  }();
 }
 
 String? _keyFor(Element? element) {
@@ -155,4 +185,34 @@ String? _keyFor(Element? element) {
       .firstAnnotationOf(element)
       ?.getField('key')!
       .toStringValue();
+}
+
+bool? _getIncludeFromJson(Element? element) {
+  if (element == null) {
+    return null;
+  }
+  return fieldChecker
+      .firstAnnotationOf(element)
+      ?.getField('includeFromJson')
+      ?.toBoolValue();
+}
+
+bool? _getIncludeToJson(Element? element) {
+  if (element == null) {
+    return null;
+  }
+  return fieldChecker
+      .firstAnnotationOf(element)
+      ?.getField('includeToJson')
+      ?.toBoolValue();
+}
+
+bool? _getIncludeIfNull(Element? element) {
+  if (element == null) {
+    return null;
+  }
+  return fieldChecker
+      .firstAnnotationOf(element)
+      ?.getField('includeIfNull')
+      ?.toBoolValue();
 }

--- a/packages/dart_mappable_builder/lib/src/elements/field/mapper_field_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/field/mapper_field_element.dart
@@ -31,6 +31,12 @@ abstract class MapperFieldElement {
   String get arg;
 
   Future<String> get hook;
+
+  String get includeFromJson;
+
+  String get includeToJson;
+
+  String get includeIfNull;
 }
 
 Future<String?> hookFor(Element? element) async {
@@ -41,6 +47,45 @@ Future<String?> hookFor(Element? element) async {
     var node = await getResolvedAnnotationNode(element, MappableField, 'hook');
     if (node != null) {
       return node.toSource();
+    }
+  }
+  return null;
+}
+
+Future<bool?> includeFromJsonFor(Element? element) async {
+  if (element == null) {
+    return null;
+  }
+  if (fieldChecker.hasAnnotationOf(element)) {
+    var annotation = fieldChecker.firstAnnotationOf(element);
+    if (annotation != null) {
+      return annotation.read('includeFromJson')?.toBoolValue();
+    }
+  }
+  return null;
+}
+
+Future<bool?> includeToJsonFor(Element? element) async {
+  if (element == null) {
+    return null;
+  }
+  if (fieldChecker.hasAnnotationOf(element)) {
+    var annotation = fieldChecker.firstAnnotationOf(element);
+    if (annotation != null) {
+      return annotation.read('includeToJson')?.toBoolValue();
+    }
+  }
+  return null;
+}
+
+Future<bool?> includeIfNullFor(Element? element) async {
+  if (element == null) {
+    return null;
+  }
+  if (fieldChecker.hasAnnotationOf(element)) {
+    var annotation = fieldChecker.firstAnnotationOf(element);
+    if (annotation != null) {
+      return annotation.read('includeIfNull')?.toBoolValue();
     }
   }
   return null;

--- a/packages/dart_mappable_builder/lib/src/elements/field/record_mapper_field_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/field/record_mapper_field_element.dart
@@ -85,4 +85,13 @@ class RecordMapperFieldElement extends MapperFieldElement {
     var hook = await param.getHook();
     return hook != null ? ', hook: $hook' : '';
   }();
+
+  @override
+  String get includeFromJson => '';
+
+  @override
+  String get includeToJson => '';
+
+  @override
+  String get includeIfNull => '';
 }

--- a/packages/dart_mappable_builder/lib/src/generators/extensions/fields_extension.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/extensions/fields_extension.dart
@@ -24,7 +24,7 @@ extension FieldsExtension<T extends InterfaceMapperElement>
         );
       }
       output.write(
-        "  static const Field<${element.prefixedClassName}, ${f.staticArgType}> _f\$${f.name} = Field('${f.name.replaceAll(r'$', r'\$')}', ${f.getter}${f.key}${f.mode}${f.opt}${await f.def}${f.arg}${await f.hook});\n",
+        "  static const Field<${element.prefixedClassName}, ${f.staticArgType}> _f\$${f.name} = Field('${f.name.replaceAll(r'$', r'\$')}', ${f.getter}${f.key}${f.mode}${f.opt}${await f.def}${f.arg}${await f.hook}${f.includeFromJson}${f.includeToJson}${f.includeIfNull});\n",
       );
     }
 

--- a/packages/dart_mappable_builder/lib/src/generators/mixins/decoding_mixin.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/mixins/decoding_mixin.dart
@@ -139,12 +139,25 @@ mixin DecodingMixin on MapperGenerator<TargetClassMapperElement> {
   Future<String> _generateConstructorParams() async {
     List<String> params = [];
     for (var param in element.params) {
+      // Get the corresponding field to check if it should be included in deserialization
+      var fieldName = param.accessor?.name ?? param.parameter.name;
+      var field = element.fields.firstWhere(
+        (f) => f.name == fieldName,
+        orElse: () => throw StateError('Field $fieldName not found'),
+      );
+
       var str = '';
 
       if (param.parameter.isNamed) {
         str = '${param.parameter.name ?? ''}: ';
       }
-      str += 'data.dec(_f\$${param.accessor?.name ?? param.parameter.name})';
+
+      // If includeFromJson is false, pass null instead of decoding the value
+      if (field.includeFromJson.contains('includeFromJson: false')) {
+        str += 'null';
+      } else {
+        str += 'data.dec(_f\$$fieldName)';
+      }
 
       params.add(str);
     }


### PR DESCRIPTION
Enhance field serialization control with @MappableField options
- Introduced `includeFromJson`, `includeToJson`, and `includeIfNull` parameters to the `@MappableField` annotation for better control over field inclusion during serialization and deserialization.
- Updated relevant documentation to reflect these changes and provide usage examples.
- Adjusted internal logic to respect these new parameters in the mapping process.
- Improved formatting and consistency in the README and model documentation.

This update enhances the flexibility of the `dart_mappable` library, allowing developers to fine-tune how fields are handled in JSON operations.