### PR TITLE
Mappable Base Implementation

### DIFF
--- a/packages/dart_mappable/lib/dart_mappable.dart
+++ b/packages/dart_mappable/lib/dart_mappable.dart
@@ -23,3 +23,4 @@ export 'src/mappers/mapper_mixins.dart';
 export 'src/mappers/mapping_context.dart';
 export 'src/mappers/record_mapper.dart';
 export 'src/mappers/simple_mapper.dart';
+export 'src/mappers/mappable_base.dart';

--- a/packages/dart_mappable/lib/src/mappers/mappable_base.dart
+++ b/packages/dart_mappable/lib/src/mappers/mappable_base.dart
@@ -1,0 +1,18 @@
+import '../../dart_mappable.dart';
+
+mixin MappableBase<T> {
+  String toJson();
+
+  Map<String, dynamic> toMap();
+
+  @override
+  String toString();
+
+  @override
+  bool operator ==(Object other);
+
+  @override
+  int get hashCode;
+
+  ClassCopyWith<T, T, T> get copyWith;
+}

--- a/packages/dart_mappable_builder/lib/src/generators/class_mapper_generator.dart
+++ b/packages/dart_mappable_builder/lib/src/generators/class_mapper_generator.dart
@@ -85,7 +85,7 @@ class ClassMapperGenerator extends MapperGenerator<TargetClassMapperElement>
     await _checkMixinUsed();
 
     output.write(
-      'mixin ${element.uniqueClassName}Mappable${element.typeParamsDeclaration} {\n',
+      'mixin ${element.uniqueClassName}Mappable${element.typeParamsDeclaration} implements MappableBase {\n',
     );
 
     generateEncoderMixin(output);


### PR DESCRIPTION
### Motivation

I would like to announce my classes that uses mappable generator has the mapable mixin abilities like copyWith, toMap, fromMap etc so I can use like that without extra flags in mappable classes.
```
class MyService<T extends MappableBase> {
  void convertToJson(T value) {
    final json = value.toMap();
  }
}
```



