### PR TITLE
Support typedef enums marked with @MappableEnum

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1.3
         with:
-          sdk: 3.8.0
+          sdk: 3.9.0
 
       - name: Bootstrap
         run: |

--- a/examples/fic_mappable/lib/main.mapper.dart
+++ b/examples/fic_mappable/lib/main.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -53,7 +54,7 @@ mixin AMappable {
   }
 
   ACopyWith<A, A, A> get copyWith =>
-      _ACopyWithImpl(this as A, $identity, $identity);
+      _ACopyWithImpl<A, A>(this as A, $identity, $identity);
   @override
   String toString() {
     return AMapper.ensureInitialized().stringifyValue(this as A);
@@ -72,7 +73,7 @@ mixin AMappable {
 
 extension AValueCopy<$R, $Out> on ObjectCopyWith<$R, A, $Out> {
   ACopyWith<$R, A, $Out> get $asA =>
-      $base.as((v, t, t2) => _ACopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _ACopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class ACopyWith<$R, $In extends A, $Out>
@@ -95,7 +96,7 @@ class _ACopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, A, $Out>
 
   @override
   ACopyWith<$R2, A, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _ACopyWithImpl($value, $cast, t);
+      _ACopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
 class BMapper extends ClassMapperBase<B> {
@@ -144,7 +145,7 @@ mixin BMappable {
   }
 
   BCopyWith<B, B, B> get copyWith =>
-      _BCopyWithImpl(this as B, $identity, $identity);
+      _BCopyWithImpl<B, B>(this as B, $identity, $identity);
   @override
   String toString() {
     return BMapper.ensureInitialized().stringifyValue(this as B);
@@ -163,7 +164,7 @@ mixin BMappable {
 
 extension BValueCopy<$R, $Out> on ObjectCopyWith<$R, B, $Out> {
   BCopyWith<$R, B, $Out> get $asB =>
-      $base.as((v, t, t2) => _BCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _BCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class BCopyWith<$R, $In extends B, $Out>
@@ -186,5 +187,6 @@ class _BCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, B, $Out>
 
   @override
   BCopyWith<$R2, B, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _BCopyWithImpl($value, $cast, t);
+      _BCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/examples/freezed_mappable/lib/main.mapper.dart
+++ b/examples/freezed_mappable/lib/main.mapper.dart
@@ -84,25 +84,9 @@ class DataMapper extends SubClassMapperBase<Data> {
     _$value,
     key: r'mykey',
   );
-  static $DataCopyWith<Data> _$copyWith(Data v) => v.copyWith;
-  static const Field<Data, $DataCopyWith<Data>> _f$copyWith = Field(
-    'copyWith',
-    _$copyWith,
-    mode: FieldMode.member,
-  );
-  static int _$hashCode(Data v) => v.hashCode;
-  static const Field<Data, int> _f$hashCode = Field(
-    'hashCode',
-    _$hashCode,
-    mode: FieldMode.member,
-  );
 
   @override
-  final MappableFields<Data> fields = const {
-    #value: _f$value,
-    #copyWith: _f$copyWith,
-    #hashCode: _f$hashCode,
-  };
+  final MappableFields<Data> fields = const {#value: _f$value};
 
   @override
   final String discriminatorKey = 'type';
@@ -154,25 +138,9 @@ class LoadingMapper extends SubClassMapperBase<Loading> {
 
   static int _$value(Loading v) => v.value;
   static const Field<Loading, int> _f$value = Field('value', _$value);
-  static $LoadingCopyWith<Loading> _$copyWith(Loading v) => v.copyWith;
-  static const Field<Loading, $LoadingCopyWith<Loading>> _f$copyWith = Field(
-    'copyWith',
-    _$copyWith,
-    mode: FieldMode.member,
-  );
-  static int _$hashCode(Loading v) => v.hashCode;
-  static const Field<Loading, int> _f$hashCode = Field(
-    'hashCode',
-    _$hashCode,
-    mode: FieldMode.member,
-  );
 
   @override
-  final MappableFields<Loading> fields = const {
-    #value: _f$value,
-    #copyWith: _f$copyWith,
-    #hashCode: _f$hashCode,
-  };
+  final MappableFields<Loading> fields = const {#value: _f$value};
 
   @override
   final String discriminatorKey = 'type';
@@ -230,23 +198,11 @@ class ErrorDetailsMapper extends SubClassMapperBase<ErrorDetails> {
     _$message,
     opt: true,
   );
-  static $ErrorDetailsCopyWith<ErrorDetails> _$copyWith(ErrorDetails v) =>
-      v.copyWith;
-  static const Field<ErrorDetails, $ErrorDetailsCopyWith<ErrorDetails>>
-  _f$copyWith = Field('copyWith', _$copyWith, mode: FieldMode.member);
-  static int _$hashCode(ErrorDetails v) => v.hashCode;
-  static const Field<ErrorDetails, int> _f$hashCode = Field(
-    'hashCode',
-    _$hashCode,
-    mode: FieldMode.member,
-  );
 
   @override
   final MappableFields<ErrorDetails> fields = const {
     #value: _f$value,
     #message: _f$message,
-    #copyWith: _f$copyWith,
-    #hashCode: _f$hashCode,
   };
 
   @override

--- a/examples/polymorph_copywith/lib/models/animal.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/animal.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -59,3 +60,4 @@ abstract class AnimalCopyWith<$R, $In extends Animal, $Out>
   $R call({String? name});
   AnimalCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
+

--- a/examples/polymorph_copywith/lib/models/cat.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/cat.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -25,11 +26,11 @@ class CatTypeMapper extends EnumMapper<CatType> {
   @override
   CatType decode(dynamic value) {
     switch (value) {
-      case 'black':
+      case r'black':
         return CatType.black;
-      case 'siamese':
+      case r'siamese':
         return CatType.siamese;
-      case 'tiger':
+      case r'tiger':
         return CatType.tiger;
       default:
         throw MapperException.unknownEnumValue(value);
@@ -40,11 +41,11 @@ class CatTypeMapper extends EnumMapper<CatType> {
   dynamic encode(CatType self) {
     switch (self) {
       case CatType.black:
-        return 'black';
+        return r'black';
       case CatType.siamese:
-        return 'siamese';
+        return r'siamese';
       case CatType.tiger:
-        return 'tiger';
+        return r'tiger';
     }
   }
 }
@@ -119,7 +120,7 @@ mixin CatMappable {
   }
 
   CatCopyWith<Cat, Cat, Cat> get copyWith =>
-      _CatCopyWithImpl(this as Cat, $identity, $identity);
+      _CatCopyWithImpl<Cat, Cat>(this as Cat, $identity, $identity);
   @override
   String toString() {
     return CatMapper.ensureInitialized().stringifyValue(this as Cat);
@@ -138,7 +139,7 @@ mixin CatMappable {
 
 extension CatValueCopy<$R, $Out> on ObjectCopyWith<$R, Cat, $Out> {
   CatCopyWith<$R, Cat, $Out> get $asCat =>
-      $base.as((v, t, t2) => _CatCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _CatCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class CatCopyWith<$R, $In extends Cat, $Out>
@@ -171,5 +172,6 @@ class _CatCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Cat, $Out>
 
   @override
   CatCopyWith<$R2, Cat, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _CatCopyWithImpl($value, $cast, t);
+      _CatCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/examples/polymorph_copywith/lib/models/dog.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/dog.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -69,7 +70,7 @@ mixin DogMappable {
   }
 
   DogCopyWith<Dog, Dog, Dog> get copyWith =>
-      _DogCopyWithImpl(this as Dog, $identity, $identity);
+      _DogCopyWithImpl<Dog, Dog>(this as Dog, $identity, $identity);
   @override
   String toString() {
     return DogMapper.ensureInitialized().stringifyValue(this as Dog);
@@ -88,7 +89,7 @@ mixin DogMappable {
 
 extension DogValueCopy<$R, $Out> on ObjectCopyWith<$R, Dog, $Out> {
   DogCopyWith<$R, Dog, $Out> get $asDog =>
-      $base.as((v, t, t2) => _DogCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _DogCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class DogCopyWith<$R, $In extends Dog, $Out>
@@ -125,5 +126,6 @@ class _DogCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Dog, $Out>
 
   @override
   DogCopyWith<$R2, Dog, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _DogCopyWithImpl($value, $cast, t);
+      _DogCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/examples/polymorph_copywith/lib/models/person.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/person.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -52,7 +53,7 @@ mixin PersonMappable {
   }
 
   PersonCopyWith<Person, Person, Person> get copyWith =>
-      _PersonCopyWithImpl(this as Person, $identity, $identity);
+      _PersonCopyWithImpl<Person, Person>(this as Person, $identity, $identity);
   @override
   String toString() {
     return PersonMapper.ensureInitialized().stringifyValue(this as Person);
@@ -71,7 +72,7 @@ mixin PersonMappable {
 
 extension PersonValueCopy<$R, $Out> on ObjectCopyWith<$R, Person, $Out> {
   PersonCopyWith<$R, Person, $Out> get $asPerson =>
-      $base.as((v, t, t2) => _PersonCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _PersonCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class PersonCopyWith<$R, $In extends Person, $Out>
@@ -94,5 +95,6 @@ class _PersonCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Person, $Out>
 
   @override
   PersonCopyWith<$R2, Person, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _PersonCopyWithImpl($value, $cast, t);
+      _PersonCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
+

--- a/examples/polymorph_copywith/lib/models/zoo.mapper.dart
+++ b/examples/polymorph_copywith/lib/models/zoo.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -21,7 +22,8 @@ class ZooMapper extends ClassMapperBase<Zoo> {
   @override
   final String id = 'Zoo';
   @override
-  Function get typeFactory => <T extends Animal>(f) => f<Zoo<T>>();
+  Function get typeFactory =>
+      <T extends Animal>(f) => f<Zoo<T>>();
 
   static List<Animal> _$animals(Zoo v) => v.animals;
   static dynamic _arg$animals<T extends Animal>(f) => f<List<T>>();
@@ -60,7 +62,7 @@ mixin ZooMappable<T extends Animal> {
   }
 
   ZooCopyWith<Zoo<T>, Zoo<T>, Zoo<T>, T> get copyWith =>
-      _ZooCopyWithImpl(this as Zoo<T>, $identity, $identity);
+      _ZooCopyWithImpl<Zoo<T>, Zoo<T>, T>(this as Zoo<T>, $identity, $identity);
   @override
   String toString() {
     return ZooMapper.ensureInitialized().stringifyValue(this as Zoo<T>);
@@ -80,7 +82,7 @@ mixin ZooMappable<T extends Animal> {
 extension ZooValueCopy<$R, $Out, T extends Animal>
     on ObjectCopyWith<$R, Zoo<T>, $Out> {
   ZooCopyWith<$R, Zoo<T>, $Out, T> get $asZoo =>
-      $base.as((v, t, t2) => _ZooCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _ZooCopyWithImpl<$R, $Out, T>(v, t, t2));
 }
 
 abstract class ZooCopyWith<$R, $In extends Zoo<T>, $Out, T extends Animal>
@@ -112,5 +114,6 @@ class _ZooCopyWithImpl<$R, $Out, T extends Animal>
 
   @override
   ZooCopyWith<$R2, Zoo<T>, $Out2, T> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _ZooCopyWithImpl($value, $cast, t);
+      _ZooCopyWithImpl<$R2, $Out2, T>($value, $cast, t);
 }
+

--- a/packages/dart_mappable/example/lib/main.mapper.dart
+++ b/packages/dart_mappable/example/lib/main.mapper.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
 // ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
@@ -25,11 +26,11 @@ class BrandMapper extends EnumMapper<Brand> {
   @override
   Brand decode(dynamic value) {
     switch (value) {
-      case 'Toyota':
+      case r'Toyota':
         return Brand.Toyota;
-      case 'Audi':
+      case r'Audi':
         return Brand.Audi;
-      case 'BMW':
+      case r'BMW':
         return Brand.BMW;
       default:
         throw MapperException.unknownEnumValue(value);
@@ -40,11 +41,11 @@ class BrandMapper extends EnumMapper<Brand> {
   dynamic encode(Brand self) {
     switch (self) {
       case Brand.Toyota:
-        return 'Toyota';
+        return r'Toyota';
       case Brand.Audi:
-        return 'Audi';
+        return r'Audi';
       case Brand.BMW:
-        return 'BMW';
+        return r'BMW';
     }
   }
 }
@@ -74,8 +75,12 @@ class PersonMapper extends ClassMapperBase<Person> {
   static String _$name(Person v) => v.name;
   static const Field<Person, String> _f$name = Field('name', _$name);
   static int _$age(Person v) => v.age;
-  static const Field<Person, int> _f$age =
-      Field('age', _$age, opt: true, def: 18);
+  static const Field<Person, int> _f$age = Field(
+    'age',
+    _$age,
+    opt: true,
+    def: 18,
+  );
   static Car? _$car(Person v) => v.car;
   static const Field<Person, Car> _f$car = Field('car', _$car, opt: true);
 
@@ -87,8 +92,11 @@ class PersonMapper extends ClassMapperBase<Person> {
   };
 
   static Person _instantiate(DecodingData data) {
-    return Person(data.dec(_f$name),
-        age: data.dec(_f$age), car: data.dec(_f$car));
+    return Person(
+      data.dec(_f$name),
+      age: data.dec(_f$age),
+      car: data.dec(_f$car),
+    );
   }
 
   @override
@@ -113,7 +121,7 @@ mixin PersonMappable {
   }
 
   PersonCopyWith<Person, Person, Person> get copyWith =>
-      _PersonCopyWithImpl(this as Person, $identity, $identity);
+      _PersonCopyWithImpl<Person, Person>(this as Person, $identity, $identity);
   @override
   String toString() {
     return PersonMapper.ensureInitialized().stringifyValue(this as Person);
@@ -132,7 +140,7 @@ mixin PersonMappable {
 
 extension PersonValueCopy<$R, $Out> on ObjectCopyWith<$R, Person, $Out> {
   PersonCopyWith<$R, Person, $Out> get $asPerson =>
-      $base.as((v, t, t2) => _PersonCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _PersonCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class PersonCopyWith<$R, $In extends Person, $Out>
@@ -152,19 +160,23 @@ class _PersonCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Person, $Out>
   CarCopyWith<$R, Car, Car>? get car =>
       $value.car?.copyWith.$chain((v) => call(car: v));
   @override
-  $R call({String? name, int? age, Object? car = $none}) =>
-      $apply(FieldCopyWithData({
-        if (name != null) #name: name,
-        if (age != null) #age: age,
-        if (car != $none) #car: car
-      }));
+  $R call({String? name, int? age, Object? car = $none}) => $apply(
+        FieldCopyWithData({
+          if (name != null) #name: name,
+          if (age != null) #age: age,
+          if (car != $none) #car: car,
+        }),
+      );
   @override
-  Person $make(CopyWithData data) => Person(data.get(#name, or: $value.name),
-      age: data.get(#age, or: $value.age), car: data.get(#car, or: $value.car));
+  Person $make(CopyWithData data) => Person(
+        data.get(#name, or: $value.name),
+        age: data.get(#age, or: $value.age),
+        car: data.get(#car, or: $value.car),
+      );
 
   @override
   PersonCopyWith<$R2, Person, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _PersonCopyWithImpl($value, $cast, t);
+      _PersonCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
 class CarMapper extends ClassMapperBase<Car> {
@@ -188,10 +200,7 @@ class CarMapper extends ClassMapperBase<Car> {
   static const Field<Car, Brand> _f$brand = Field('brand', _$brand);
 
   @override
-  final MappableFields<Car> fields = const {
-    #miles: _f$miles,
-    #brand: _f$brand,
-  };
+  final MappableFields<Car> fields = const {#miles: _f$miles, #brand: _f$brand};
 
   static Car _instantiate(DecodingData data) {
     return Car(data.dec(_f$miles), data.dec(_f$brand));
@@ -219,7 +228,7 @@ mixin CarMappable {
   }
 
   CarCopyWith<Car, Car, Car> get copyWith =>
-      _CarCopyWithImpl(this as Car, $identity, $identity);
+      _CarCopyWithImpl<Car, Car>(this as Car, $identity, $identity);
   @override
   String toString() {
     return CarMapper.ensureInitialized().stringifyValue(this as Car);
@@ -238,7 +247,7 @@ mixin CarMappable {
 
 extension CarValueCopy<$R, $Out> on ObjectCopyWith<$R, Car, $Out> {
   CarCopyWith<$R, Car, $Out> get $asCar =>
-      $base.as((v, t, t2) => _CarCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _CarCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class CarCopyWith<$R, $In extends Car, $Out>
@@ -254,15 +263,21 @@ class _CarCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Car, $Out>
   @override
   late final ClassMapperBase<Car> $mapper = CarMapper.ensureInitialized();
   @override
-  $R call({double? miles, Brand? brand}) => $apply(FieldCopyWithData(
-      {if (miles != null) #miles: miles, if (brand != null) #brand: brand}));
+  $R call({double? miles, Brand? brand}) => $apply(
+        FieldCopyWithData({
+          if (miles != null) #miles: miles,
+          if (brand != null) #brand: brand,
+        }),
+      );
   @override
   Car $make(CopyWithData data) => Car(
-      data.get(#miles, or: $value.miles), data.get(#brand, or: $value.brand));
+        data.get(#miles, or: $value.miles),
+        data.get(#brand, or: $value.brand),
+      );
 
   @override
   CarCopyWith<$R2, Car, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _CarCopyWithImpl($value, $cast, t);
+      _CarCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }
 
 class BoxMapper extends ClassMapperBase<Box> {
@@ -285,8 +300,11 @@ class BoxMapper extends ClassMapperBase<Box> {
   static const Field<Box, int> _f$size = Field('size', _$size);
   static dynamic _$content(Box v) => v.content;
   static dynamic _arg$content<T>(f) => f<T>();
-  static const Field<Box, dynamic> _f$content =
-      Field('content', _$content, arg: _arg$content);
+  static const Field<Box, dynamic> _f$content = Field(
+    'content',
+    _$content,
+    arg: _arg$content,
+  );
 
   @override
   final MappableFields<Box> fields = const {
@@ -320,7 +338,7 @@ mixin BoxMappable<T> {
   }
 
   BoxCopyWith<Box<T>, Box<T>, Box<T>, T> get copyWith =>
-      _BoxCopyWithImpl(this as Box<T>, $identity, $identity);
+      _BoxCopyWithImpl<Box<T>, Box<T>, T>(this as Box<T>, $identity, $identity);
   @override
   String toString() {
     return BoxMapper.ensureInitialized().stringifyValue(this as Box<T>);
@@ -339,7 +357,7 @@ mixin BoxMappable<T> {
 
 extension BoxValueCopy<$R, $Out, T> on ObjectCopyWith<$R, Box<T>, $Out> {
   BoxCopyWith<$R, Box<T>, $Out, T> get $asBox =>
-      $base.as((v, t, t2) => _BoxCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _BoxCopyWithImpl<$R, $Out, T>(v, t, t2));
 }
 
 abstract class BoxCopyWith<$R, $In extends Box<T>, $Out, T>
@@ -355,15 +373,21 @@ class _BoxCopyWithImpl<$R, $Out, T> extends ClassCopyWithBase<$R, Box<T>, $Out>
   @override
   late final ClassMapperBase<Box> $mapper = BoxMapper.ensureInitialized();
   @override
-  $R call({int? size, T? content}) => $apply(FieldCopyWithData(
-      {if (size != null) #size: size, if (content != null) #content: content}));
+  $R call({int? size, Object? content = $none}) => $apply(
+        FieldCopyWithData({
+          if (size != null) #size: size,
+          if (content != $none) #content: content,
+        }),
+      );
   @override
-  Box<T> $make(CopyWithData data) => Box(data.get(#size, or: $value.size),
-      content: data.get(#content, or: $value.content));
+  Box<T> $make(CopyWithData data) => Box(
+        data.get(#size, or: $value.size),
+        content: data.get(#content, or: $value.content),
+      );
 
   @override
   BoxCopyWith<$R2, Box<T>, $Out2, T> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
-      _BoxCopyWithImpl($value, $cast, t);
+      _BoxCopyWithImpl<$R2, $Out2, T>($value, $cast, t);
 }
 
 class ConfettiMapper extends ClassMapperBase<Confetti> {
@@ -384,9 +408,7 @@ class ConfettiMapper extends ClassMapperBase<Confetti> {
   static const Field<Confetti, String> _f$color = Field('color', _$color);
 
   @override
-  final MappableFields<Confetti> fields = const {
-    #color: _f$color,
-  };
+  final MappableFields<Confetti> fields = const {#color: _f$color};
 
   static Confetti _instantiate(DecodingData data) {
     return Confetti(data.dec(_f$color));
@@ -406,17 +428,23 @@ class ConfettiMapper extends ClassMapperBase<Confetti> {
 
 mixin ConfettiMappable {
   String toJson() {
-    return ConfettiMapper.ensureInitialized()
-        .encodeJson<Confetti>(this as Confetti);
+    return ConfettiMapper.ensureInitialized().encodeJson<Confetti>(
+      this as Confetti,
+    );
   }
 
   Map<String, dynamic> toMap() {
-    return ConfettiMapper.ensureInitialized()
-        .encodeMap<Confetti>(this as Confetti);
+    return ConfettiMapper.ensureInitialized().encodeMap<Confetti>(
+      this as Confetti,
+    );
   }
 
   ConfettiCopyWith<Confetti, Confetti, Confetti> get copyWith =>
-      _ConfettiCopyWithImpl(this as Confetti, $identity, $identity);
+      _ConfettiCopyWithImpl<Confetti, Confetti>(
+        this as Confetti,
+        $identity,
+        $identity,
+      );
   @override
   String toString() {
     return ConfettiMapper.ensureInitialized().stringifyValue(this as Confetti);
@@ -424,8 +452,10 @@ mixin ConfettiMappable {
 
   @override
   bool operator ==(Object other) {
-    return ConfettiMapper.ensureInitialized()
-        .equalsValue(this as Confetti, other);
+    return ConfettiMapper.ensureInitialized().equalsValue(
+      this as Confetti,
+      other,
+    );
   }
 
   @override
@@ -436,7 +466,7 @@ mixin ConfettiMappable {
 
 extension ConfettiValueCopy<$R, $Out> on ObjectCopyWith<$R, Confetti, $Out> {
   ConfettiCopyWith<$R, Confetti, $Out> get $asConfetti =>
-      $base.as((v, t, t2) => _ConfettiCopyWithImpl(v, t, t2));
+      $base.as((v, t, t2) => _ConfettiCopyWithImpl<$R, $Out>(v, t, t2));
 }
 
 abstract class ConfettiCopyWith<$R, $In extends Confetti, $Out>
@@ -462,6 +492,7 @@ class _ConfettiCopyWithImpl<$R, $Out>
 
   @override
   ConfettiCopyWith<$R2, Confetti, $Out2> $chain<$R2, $Out2>(
-          Then<$Out2, $R2> t) =>
-      _ConfettiCopyWithImpl($value, $cast, t);
+    Then<$Out2, $R2> t,
+  ) =>
+      _ConfettiCopyWithImpl<$R2, $Out2>($value, $cast, t);
 }

--- a/packages/dart_mappable/test/external_types/external_types_test.dart
+++ b/packages/dart_mappable/test/external_types/external_types_test.dart
@@ -4,6 +4,7 @@ library;
 import 'package:dart_mappable/dart_mappable.dart';
 import 'package:test/test.dart';
 
+import 'other/color.dart' as c;
 import 'other/food.dart' as f;
 import 'other/models.dart' as m;
 import 'other/other.dart' as o;
@@ -22,6 +23,9 @@ typedef Animal = o.Animal;
 @MappableClass()
 typedef Pet = o.Pet;
 
+@MappableEnum(caseStyle: CaseStyle.pascalCase)
+typedef Color = c.Color;
+
 @MappableClass()
 class Person with PersonMappable {
   final String firstName;
@@ -36,10 +40,11 @@ void main() {
       expect(Cake('Lemon').toMap(), equals({'type': 'Lemon'}));
       expect(Person('Anna').toMap(), equals({'first_name': 'Anna'}));
       expect(
-        Pet(Person2('Clara'), 'Buddy').toMap(),
+        Pet(Person2('Clara'), 'Buddy', Color.black).toMap(),
         equals({
           'owner': {'first_name': 'Clara'},
-          'color': 'Buddy',
+          'name': 'Buddy',
+          'color': 'Black',
           'type': 'Pet',
         }),
       );
@@ -49,9 +54,10 @@ void main() {
           AnimalMapper.fromMap({
             'type': 'Pet',
             'owner': {'first_name': 'Clara'},
-            'color': 'Buddy',
+            'name': 'Buddy',
+            'color': 'White',
           }),
-          Pet(Person2('Clara'), 'Buddy'),
+          Pet(Person2('Clara'), 'Buddy', Color.white),
         ),
         isTrue,
       );

--- a/packages/dart_mappable/test/external_types/external_types_test.mapper.dart
+++ b/packages/dart_mappable/test/external_types/external_types_test.mapper.dart
@@ -273,6 +273,7 @@ class AnimalMapper extends ClassMapperBase<o.Animal> {
     if (_instance == null) {
       MapperContainer.globals.use(_instance = AnimalMapper._());
       PetMapper.ensureInitialized();
+      ColorMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -280,11 +281,16 @@ class AnimalMapper extends ClassMapperBase<o.Animal> {
   @override
   final String id = 'Animal';
 
-  static String _$color(o.Animal v) => v.color;
-  static const Field<o.Animal, String> _f$color = Field('color', _$color);
+  static String _$name(o.Animal v) => v.name;
+  static const Field<o.Animal, String> _f$name = Field('name', _$name);
+  static c.Color _$color(o.Animal v) => v.color;
+  static const Field<o.Animal, c.Color> _f$color = Field('color', _$color);
 
   @override
-  final MappableFields<o.Animal> fields = const {#color: _f$color};
+  final MappableFields<o.Animal> fields = const {
+    #name: _f$name,
+    #color: _f$color,
+  };
 
   static o.Animal _instantiate(DecodingData data) {
     throw MapperException.missingSubclass(
@@ -318,7 +324,7 @@ extension AnimalMapperExtension on o.Animal {
 
 abstract class AnimalCopyWith<$R, $In extends o.Animal, $Out>
     implements ClassCopyWith<$R, $In, $Out> {
-  $R call({String? color});
+  $R call({String? name, c.Color? color});
   AnimalCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -331,6 +337,7 @@ class PetMapper extends SubClassMapperBase<o.Pet> {
       MapperContainer.globals.use(_instance = PetMapper._());
       AnimalMapper.ensureInitialized().addSubMapper(_instance!);
       Person2Mapper.ensureInitialized();
+      ColorMapper.ensureInitialized();
     }
     return _instance!;
   }
@@ -340,12 +347,15 @@ class PetMapper extends SubClassMapperBase<o.Pet> {
 
   static m.Person _$owner(o.Pet v) => v.owner;
   static const Field<o.Pet, m.Person> _f$owner = Field('owner', _$owner);
-  static String _$color(o.Pet v) => v.color;
-  static const Field<o.Pet, String> _f$color = Field('color', _$color);
+  static String _$name(o.Pet v) => v.name;
+  static const Field<o.Pet, String> _f$name = Field('name', _$name);
+  static c.Color _$color(o.Pet v) => v.color;
+  static const Field<o.Pet, c.Color> _f$color = Field('color', _$color);
 
   @override
   final MappableFields<o.Pet> fields = const {
     #owner: _f$owner,
+    #name: _f$name,
     #color: _f$color,
   };
 
@@ -357,7 +367,7 @@ class PetMapper extends SubClassMapperBase<o.Pet> {
   late final ClassMapperBase superMapper = AnimalMapper.ensureInitialized();
 
   static o.Pet _instantiate(DecodingData data) {
-    return o.Pet(data.dec(_f$owner), data.dec(_f$color));
+    return o.Pet(data.dec(_f$owner), data.dec(_f$name), data.dec(_f$color));
   }
 
   @override
@@ -394,7 +404,7 @@ abstract class PetCopyWith<$R, $In extends o.Pet, $Out>
     implements AnimalCopyWith<$R, $In, $Out> {
   Person2CopyWith<$R, m.Person, m.Person> get owner;
   @override
-  $R call({m.Person? owner, String? color});
+  $R call({m.Person? owner, String? name, c.Color? color});
   PetCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
 }
 
@@ -408,20 +418,72 @@ class _PetCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, o.Pet, $Out>
   Person2CopyWith<$R, m.Person, m.Person> get owner =>
       $value.owner.copyWith.$chain((v) => call(owner: v));
   @override
-  $R call({m.Person? owner, String? color}) => $apply(
+  $R call({m.Person? owner, String? name, c.Color? color}) => $apply(
     FieldCopyWithData({
       if (owner != null) #owner: owner,
+      if (name != null) #name: name,
       if (color != null) #color: color,
     }),
   );
   @override
   o.Pet $make(CopyWithData data) => o.Pet(
     data.get(#owner, or: $value.owner),
+    data.get(#name, or: $value.name),
     data.get(#color, or: $value.color),
   );
 
   @override
   PetCopyWith<$R2, o.Pet, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
       _PetCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+
+class ColorMapper extends EnumMapper<c.Color> {
+  ColorMapper._();
+
+  static ColorMapper? _instance;
+  static ColorMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = ColorMapper._());
+    }
+    return _instance!;
+  }
+
+  static c.Color fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  c.Color decode(dynamic value) {
+    switch (value) {
+      case r'Black':
+        return c.Color.black;
+      case r'Red':
+        return c.Color.red;
+      case r'White':
+        return c.Color.white;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(c.Color self) {
+    switch (self) {
+      case c.Color.black:
+        return r'Black';
+      case c.Color.red:
+        return r'Red';
+      case c.Color.white:
+        return r'White';
+    }
+  }
+}
+
+extension ColorMapperExtension on c.Color {
+  String toValue() {
+    ColorMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<c.Color>(this) as String;
+  }
 }
 

--- a/packages/dart_mappable/test/external_types/other/color.dart
+++ b/packages/dart_mappable/test/external_types/other/color.dart
@@ -1,0 +1,1 @@
+enum Color { black, red, white }

--- a/packages/dart_mappable/test/external_types/other/other.dart
+++ b/packages/dart_mappable/test/external_types/other/other.dart
@@ -1,13 +1,15 @@
+import 'color.dart';
 import 'models.dart';
 
 abstract class Animal {
-  final String color;
+  final String name;
+  final Color color;
 
-  const Animal(this.color);
+  const Animal(this.name, this.color);
 }
 
 class Pet extends Animal {
   final Person owner;
 
-  const Pet(this.owner, super.color);
+  const Pet(this.owner, super.name, super.color);
 }

--- a/packages/dart_mappable_builder/lib/src/elements/class/alias_class_mapper_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/class/alias_class_mapper_element.dart
@@ -7,7 +7,7 @@ import '../constructor/constructor_mapper_element.dart';
 import '../mapper_element.dart';
 import 'target_class_mapper_element.dart';
 
-/// Element interface for all annotated type aliases.
+/// Element interface for all annotated class type aliases.
 class AliasClassMapperElement extends TargetClassMapperElement {
   AliasClassMapperElement._(
     super.parent,

--- a/packages/dart_mappable_builder/lib/src/elements/enum/alias_enum_mapper_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/enum/alias_enum_mapper_element.dart
@@ -1,0 +1,44 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:dart_mappable/dart_mappable.dart';
+
+import '../../builder_options.dart';
+import '../../mapper_group.dart';
+import '../mapper_element.dart';
+import 'target_enum_mapper_element.dart';
+
+/// Element interface for all annotated enum type aliases.
+class AliasEnumMapperElement extends TargetEnumMapperElement {
+  AliasEnumMapperElement._(
+    super.parent,
+    this.alias,
+    super.element,
+    super.options,
+    super.annotation,
+    super.valueNodes,
+  );
+
+  final TypeAliasElement alias;
+
+  static Future<AliasEnumMapperElement> from(
+    MapperElementGroup parent,
+    TypeAliasElement alias,
+    MappableOptions options,
+  ) async {
+    var element = alias.aliasedType.element as EnumElement;
+
+    var annotation = await MapperAnnotation.from<MappableEnum>(alias);
+    var valueNodes = await TargetEnumMapperElement.getValues(element);
+
+    return AliasEnumMapperElement._(
+      parent,
+      alias,
+      element,
+      options,
+      annotation,
+      valueNodes,
+    );
+  }
+
+  @override
+  late final String uniqueClassName = alias.name ?? '';
+}

--- a/packages/dart_mappable_builder/lib/src/elements/enum/target_enum_mapper_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/enum/target_enum_mapper_element.dart
@@ -10,7 +10,7 @@ import '../mapper_element.dart';
 import 'enum_mapper_element.dart';
 
 class TargetEnumMapperElement extends EnumMapperElement {
-  TargetEnumMapperElement._(
+  TargetEnumMapperElement(
     super.parent,
     super.element,
     super.options,
@@ -24,9 +24,9 @@ class TargetEnumMapperElement extends EnumMapperElement {
     MappableOptions options,
   ) async {
     var annotation = await MapperAnnotation.from<MappableEnum>(element);
-    var valueNodes = await _getValues(element);
+    var valueNodes = await getValues(element);
 
-    return TargetEnumMapperElement._(
+    return TargetEnumMapperElement(
       parent,
       element,
       options,
@@ -73,7 +73,7 @@ class TargetEnumMapperElement extends EnumMapperElement {
         }
       }).toList();
 
-  static Future<List<(FieldElement, AstNode?)>> _getValues(
+  static Future<List<(FieldElement, AstNode?)>> getValues(
     EnumElement element,
   ) async {
     var fields = element.fields.where((f) => f.isEnumConstant).toList();

--- a/packages/dart_mappable_builder/lib/src/mapper_group.dart
+++ b/packages/dart_mappable_builder/lib/src/mapper_group.dart
@@ -12,6 +12,7 @@ import 'elements/class/class_mapper_element.dart';
 import 'elements/class/dependent_class_mapper_element.dart';
 import 'elements/class/factory_constructor_mapper_element.dart';
 import 'elements/class/target_class_mapper_element.dart';
+import 'elements/enum/alias_enum_mapper_element.dart';
 import 'elements/enum/dependent_enum_mapper_element.dart';
 import 'elements/enum/target_enum_mapper_element.dart';
 import 'elements/mapper_element.dart';
@@ -123,6 +124,13 @@ class MapperElementGroup {
         } else {
           return await _addMapper(
             await DependentRecordMapperElement.from(this, e, options),
+          );
+        }
+      } else if (enumChecker.hasAnnotationOf(e) &&
+          e.aliasedType.element is EnumElement) {
+        if (e.library == library) {
+          return await _addMapper(
+            await AliasEnumMapperElement.from(this, e, options),
           );
         }
       }
@@ -410,7 +418,9 @@ class MapperElementGroup {
                   ((e.aliasedType.element is ClassElement &&
                           classChecker.hasAnnotationOf(e)) ||
                       (e.aliasedType is RecordType &&
-                          recordChecker.hasAnnotationOf(e)))));
+                          recordChecker.hasAnnotationOf(e)) ||
+                      (e.aliasedType is EnumElement &&
+                          enumChecker.hasAnnotationOf(e)))));
     }
 
     if (scope == InitializerScope.package ||


### PR DESCRIPTION
## Description

Adds support for enum type aliases.
Fixes https://github.com/schultek/dart_mappable/issues/324

## What is done
1. Added [alias_enum_mapper_element.dart](https://github.com/schultek/dart_mappable/compare/main...sikrinick:dart_mappable:main?expand=1#diff-ff7233f86e9b14f9b713b6f88ba850f80d3b67ddb4ab504bbb6ca3fef9c869a1)
2. Added condition to [mapper_group.dart](https://github.com/schultek/dart_mappable/compare/main...sikrinick:dart_mappable:main?expand=1#diff-388c23f68285510e6d637841bb5865106c3e8d016a4fd70f69b4bc9f9c98c932)
3. Updated [external_types_test.dart](https://github.com/schultek/dart_mappable/compare/main...sikrinick:dart_mappable:main?expand=1#diff-b660203962b2667611210862749f7604c1ce651897dd92b56e0647b19230b031) and corresponding mapper

## How I tested
1. In `package/dart_mappable/pubspec.yaml` changed `dart_mappable_builder: ^4.6.0` to 
```
dart_mappable_builder:
  path: ../dart_mappable_builder
```
2. `cd package/dart_mappable`
3. `dart run build_runner build -d`
4. `dart test`
