### PR TITLE
Add ignore directive for protected member linting

### DIFF
--- a/packages/dart_mappable/pubspec.yaml
+++ b/packages/dart_mappable/pubspec.yaml
@@ -25,10 +25,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.14
-  dart_mappable_builder:
-    git:
-      url: https://github.com/zajrik/dart_mappable.git
-      path: packages/dart_mappable_builder
+  dart_mappable_builder: ^4.6.3
   lints: ^5.0.0
   test: ^1.25.10
 


### PR DESCRIPTION
This allows mappable classes to have members marked with `@protected` without warnings being displayed in the generated Mapper code.