### PR TITLE
Migrate to analyzer 12

### DIFF
--- a/packages/dart_mappable/CHANGELOG.md
+++ b/packages/dart_mappable/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.8.0
+
+- Bump `analyzer` to `>=10.0.0 <12.0.0`.
+
 # 4.7.0
 
 - Added `firstWhere` to `ListCopyWith` for chaining copyWith calls on a list element based on a predicate function.

--- a/packages/dart_mappable/lib/src/mappers/default_mappers.dart
+++ b/packages/dart_mappable/lib/src/mappers/default_mappers.dart
@@ -21,7 +21,7 @@ class PrimitiveMapper<T extends Object> extends MapperBase<T>
     return exactType != null ? v.runtimeType == exactType : super.isFor(v);
   }
 
-  static T _cast<T>(v) => v as T;
+  static T _cast<T>(dynamic v) => v as T;
 
   @override
   T decoder(Object value, DecodingContext context) {

--- a/packages/dart_mappable/pubspec.yaml
+++ b/packages/dart_mappable/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.14
-  dart_mappable_builder: ^4.7.0
+  dart_mappable_builder: ^4.8.0
   lints: ^6.1.0
   test: ^1.25.10
 

--- a/packages/dart_mappable/pubspec.yaml
+++ b/packages/dart_mappable/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_mappable
 description: Improved json serialization and data classes with full support for generics, inheritance, customization and more.
-version: 4.7.0
+version: 4.8.0
 repository: https://github.com/schultek/dart_mappable
 issue_tracker: https://github.com/schultek/dart_mappable/issues
 documentation: https://pub.dev/documentation/dart_mappable/latest/topics/Introduction-topic.html
@@ -26,6 +26,6 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.14
   dart_mappable_builder: ^4.7.0
-  lints: ^5.0.0
+  lints: ^6.1.0
   test: ^1.25.10
 

--- a/packages/dart_mappable/test/polymorphism/custom_discriminator_test.dart
+++ b/packages/dart_mappable/test/polymorphism/custom_discriminator_test.dart
@@ -12,7 +12,7 @@ abstract class A with AMappable {
 class B extends A with BMappable {
   B();
 
-  static bool checkType(value) {
+  static bool checkType(dynamic value) {
     return value is Map && value['isB'] == true;
   }
 }
@@ -21,7 +21,7 @@ class B extends A with BMappable {
 class C extends A with CMappable {
   C();
 
-  static bool checkType(value) {
+  static bool checkType(dynamic value) {
     return value is Map && value['isWhat'] == 'C';
   }
 }

--- a/packages/dart_mappable_builder/CHANGELOG.md
+++ b/packages/dart_mappable_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.8.0
+
+- Bump `analyzer` to `>=10.0.0 <12.0.0`.
+
 ## 4.7.0
 
 - Allow `analyzer` 10.0.0.

--- a/packages/dart_mappable_builder/lib/src/elements/class/class_mapper_element.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/class/class_mapper_element.dart
@@ -139,8 +139,7 @@ abstract class ClassMapperElement extends InterfaceMapperElement<ClassElement>
     yield* extendsElement?._allFields ?? [];
 
     for (var getter in element.getters) {
-      // ignore: deprecated_member_use
-      if (getter.isStatic || getter.isSynthetic) continue;
+      if (getter.isStatic || !getter.isOriginDeclaration) continue;
 
       if (fieldChecker.hasAnnotationOf(getter)) {
         yield getter.variable;
@@ -148,8 +147,7 @@ abstract class ClassMapperElement extends InterfaceMapperElement<ClassElement>
     }
 
     for (var field in element.fields) {
-      // ignore: deprecated_member_use
-      if (field.isStatic || field.isSynthetic) continue;
+      if (field.isStatic || !field.isOriginDeclaration) continue;
 
       if (field.isPublic || fieldChecker.hasAnnotationOf(field)) {
         yield field;

--- a/packages/dart_mappable_builder/pubspec.yaml
+++ b/packages/dart_mappable_builder/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   ansicolor: ^2.0.1
   build: ^4.0.0
   collection: ^1.15.0
-  dart_mappable: ^4.7.0
+  dart_mappable: ^4.8.0
   dart_style: ^3.0.1
   glob: ^2.1.0
   path: ^1.8.0

--- a/packages/dart_mappable_builder/pubspec.yaml
+++ b/packages/dart_mappable_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_mappable_builder
 description: Improved json serialization and data classes with full support for generics, inheritance, customization and more.
-version: 4.7.0
+version: 4.8.0
 repository: https://github.com/schultek/dart_mappable
 issue_tracker: https://github.com/schultek/dart_mappable/issues
 funding:
@@ -12,7 +12,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  analyzer: '>=8.1.0 <11.0.0'
+  analyzer: '>=10.0.0 <13.0.0'
   ansicolor: ^2.0.1
   build: ^4.0.0
   collection: ^1.15.0
@@ -25,5 +25,5 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.10.2
   build_test: ^3.3.0
-  lints: '>=1.0.0 <6.0.0'
+  lints: '>=1.0.0 <7.0.0'
   test: ^1.25.10


### PR DESCRIPTION
Migrated to the newest analyzer.
Changed the analyzer version to min 10 since this is the time isSynthetic is deprecated.

Tested running dart_mappable_builder on my Linwood Setonix repo