### PR TITLE
fix(builder): Support linked mappers in extension types

### DIFF
--- a/packages/dart_mappable_builder/lib/src/elements/class/mixins/linked_elements_mixin.dart
+++ b/packages/dart_mappable_builder/lib/src/elements/class/mixins/linked_elements_mixin.dart
@@ -35,6 +35,12 @@ List<String> findLinkedElements(
 
   void checkType(DartType t) {
     var e = t.element;
+    
+    if (e is ExtensionTypeElement) {
+      checkType(t.extensionTypeErasure);
+      return;
+    }
+
     var m = parent.getMapperForElement(e);
     if (m != null) {
       linked.add(

--- a/packages/dart_mappable_builder/test/simple_model_test.dart
+++ b/packages/dart_mappable_builder/test/simple_model_test.dart
@@ -1,9 +1,66 @@
+import 'package:build_test/build_test.dart';
 import 'package:test/test.dart';
 
 import 'utils/test_mappable.dart';
 
 void main() {
   group('simple model', () {
+    test(
+      'finds linked mappers through extension type representations',
+      () async {
+        await testMappable(
+          {
+            'model': '''
+            import 'package:dart_mappable/dart_mappable.dart';
+
+            part 'model.mapper.dart';
+
+            @MappableClass(discriminatorKey: 'type')
+            abstract class NestedModel with NestedModelMappable {
+              const NestedModel();
+            }
+
+            extension type const ModelList(List<NestedModel> value)
+                implements List<NestedModel> {}
+
+            @MappableClass()
+            class ParentModel with ParentModelMappable {
+              const ParentModel(this.models);
+
+              final ModelList models;
+            }
+          ''',
+          },
+          outputs: {
+            'model': decodedMatches(
+              predicate<String>((output) {
+                final mapperStart = output.indexOf(
+                  'static ParentModelMapper ensureInitialized()',
+                );
+                final mapperEnd = output.indexOf(
+                  '  @override\n  final String id = \'ParentModel\';',
+                  mapperStart,
+                );
+                if (mapperStart == -1 || mapperEnd == -1) return false;
+
+                final initializer = output.substring(mapperStart, mapperEnd);
+                return RegExp(
+                          r'NestedModelMapper\.ensureInitialized\(\);',
+                        ).allMatches(initializer).length ==
+                        1 &&
+                    output.contains(
+                      r'static ModelList _$models(ParentModel v)',
+                    ) &&
+                    output.contains(
+                      r'const Field<ParentModel, ModelList> _f$models = Field(',
+                    );
+              }),
+            ),
+          },
+        );
+      },
+    );
+
     test('generates correct mapper code', () async {
       await testMappable(
         {

--- a/packages/dart_mappable_builder/test/utils/test_mappable.dart
+++ b/packages/dart_mappable_builder/test/utils/test_mappable.dart
@@ -14,7 +14,7 @@ Map<String, String> singleModel(String modelClass) => {
 
 Future<void> testMappable(
   Map<String, String> inputs, {
-  Map<String, String>? outputs,
+  Map<String, Object>? outputs,
 }) async {
   final reader = TestReaderWriter(rootPackage: 'models');
   await reader.testing.loadIsolateSources();


### PR DESCRIPTION
## Summary

Adds mapper dependency discovery for extension types.
Related to #348 

### Problem

```dart
extension type const ModelList(List<NestedModel> value) implements List<NestedModel> {}

@MappableClass()
class ParentModel with ParentModelMappable {
  final ModelList models;
}
```

Previously, `ParentModelMapper` only saw `ModelList`, so it did not initialize `NestedModelMapper`.

### Solution

The builder now checks an extension type’s wrapped type when finding linked mappers. In this example, it finds `List<NestedModel>` and adds:

```dart
NestedModelMapper.ensureInitialized();
```

`ParentModel.models` remains typed as `ModelList`.

## Testing

- Added a generator test for extension-type fields.
- Verified generated fields keep their extension type.
- Ran `dart test packages/dart_mappable_builder/test/simple_model_test.dart`.

AI-assisted, then reviewed, verified, and tested.

> If you need this fix while using 4.7.0 or 4.8.0, it is also available on the [`4.7.0-fix` branch](https://github.com/DaPotatoMan/dart_mappable/tree/4.7.0-fix) and the [`4.8.0-fix` branch](https://github.com/DaPotatoMan/dart_mappable/commits/4.8.0-fix).