### PR TITLE
performance: fast path for primitive list encoder

### DIFF
--- a/packages/dart_mappable/lib/src/mapper_container.dart
+++ b/packages/dart_mappable/lib/src/mapper_container.dart
@@ -189,6 +189,12 @@ abstract class MapperContainer {
   /// Returns the current mapper for type [T] of this container.
   MapperBase<T>? get<T extends Object>([Type? type]);
 
+  /// Whether the mapper for [T] leaves values unchanged when encoding.
+  ///
+  /// For example, this returns `true` for `int` (`42` becomes `42`) and
+  /// `false` for `DateTime` (it becomes a string).
+  bool isIdentityEncoder<T>();
+
   /// Returns all mapper this container currently holds.
   List<MapperBase> getAll();
 
@@ -539,6 +545,11 @@ class _MapperContainerBase implements MapperContainer, TypeProvider {
   @override
   MapperBase<T>? get<T extends Object>([Type? type]) {
     return _mappers[(type ?? T).base] as MapperBase<T>?;
+  }
+
+  @override
+  bool isIdentityEncoder<T>() {
+    return _mapperForType(T)?.isIdentityEncoder ?? false;
   }
 
   @override

--- a/packages/dart_mappable/lib/src/mappers/default_mappers.dart
+++ b/packages/dart_mappable/lib/src/mappers/default_mappers.dart
@@ -15,6 +15,9 @@ class PrimitiveMapper<T extends Object> extends MapperBase<T>
   final Type? exactType;
 
   @override
+  bool get isIdentityEncoder => true;
+
+  @override
   Type get type => exactType ?? super.type;
   @override
   bool isFor(dynamic v) {

--- a/packages/dart_mappable/lib/src/mappers/default_mappers.dart
+++ b/packages/dart_mappable/lib/src/mappers/default_mappers.dart
@@ -15,7 +15,7 @@ class PrimitiveMapper<T extends Object> extends MapperBase<T>
   final Type? exactType;
 
   @override
-  bool get isIdentityEncoder => true;
+  bool get isIdentityEncoder => exactType == null;
 
   @override
   Type get type => exactType ?? super.type;

--- a/packages/dart_mappable/lib/src/mappers/iterable_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/iterable_mapper.dart
@@ -103,6 +103,10 @@ class _IterableEncoder<I extends Iterable> {
   }
 
   Iterable<dynamic> _encode<T>() {
+    if (context.options == null && context.container.isIdentityEncoder<T>()) {
+      return value.toList();
+    }
+
     return value
         .map((v) => context.$enc<T>(v as T, 'item', context.options))
         .toList();

--- a/packages/dart_mappable/lib/src/mappers/mapper_base.dart
+++ b/packages/dart_mappable/lib/src/mappers/mapper_base.dart
@@ -28,6 +28,13 @@ abstract class MapperBase<T extends Object> {
   bool isForType(Type type) => type.base == T;
   bool includeTypeId<V>(dynamic v) => false;
 
+  /// Whether encoding leaves a value unchanged.
+  ///
+  /// For example, the `int` mapper encodes `42` as `42`, so it returns `true`.
+  /// A `DateTime` mapper encodes a `DateTime` as a string, so it returns
+  /// `false`.
+  bool get isIdentityEncoder => false;
+
   /// The mapping method to decode [value] to an instance of this mappers type.
   T decoder(Object value, DecodingContext context) {
     throw MapperException.unsupportedMethod(MapperMethod.decode, type);

--- a/packages/dart_mappable/test/serialization/iterable_encoder_test.dart
+++ b/packages/dart_mappable/test/serialization/iterable_encoder_test.dart
@@ -1,0 +1,62 @@
+import 'package:dart_mappable/dart_mappable.dart';
+import 'package:test/test.dart';
+
+part 'iterable_encoder_test.mapper.dart';
+
+@MappableClass()
+class Foobar with FoobarMappable {
+  final int id;
+  final String name;
+
+  Foobar(this.id, this.name);
+}
+
+void main() {
+  final m = MapperContainer.globals;
+  FoobarMapper.ensureInitialized();
+
+  group('iterable encoder', () {
+    test('encodes ints', () {
+      expect(m.toValue<List<int>>([1, 2, 3]), equals([1, 2, 3]));
+    });
+
+    test('encodes nums', () {
+      expect(m.toValue<List<num>>([1, 2.5, 3]), equals([1, 2.5, 3]));
+    });
+
+    test('encodes strings and bools', () {
+      expect(m.toValue<List<String>>(['one', 'two']), equals(['one', 'two']));
+      expect(m.toValue<List<bool>>([true, false]), equals([true, false]));
+    });
+
+    test('encodes doubles', () {
+      expect(m.toValue<List<double>>([1.0, 2.5, 3.0]), equals([1.0, 2.5, 3.0]));
+    });
+
+    test('encodes dynamic and object values', () {
+      final date = DateTime.utc(2000);
+      final foobar = Foobar(4, 'four');
+      final values = [1, 'two', true, date, foobar];
+      final encodedValues = [
+        1,
+        'two',
+        true,
+        '2000-01-01T00:00:00.000Z',
+        {'id': 4, 'name': 'four', '__type': 'Foobar'},
+      ];
+
+      expect(m.toValue<List<dynamic>>(values), equals(encodedValues));
+      expect(m.toValue<List<Object>>(values), equals(encodedValues));
+    });
+
+    test('encodes mappable classes', () {
+      expect(
+        m.toValue<List<Foobar>>([Foobar(1, 'one'), Foobar(2, 'two')]),
+        equals([
+          {'id': 1, 'name': 'one'},
+          {'id': 2, 'name': 'two'},
+        ]),
+      );
+    });
+  });
+}

--- a/packages/dart_mappable/test/serialization/iterable_encoder_test.mapper.dart
+++ b/packages/dart_mappable/test/serialization/iterable_encoder_test.mapper.dart
@@ -1,0 +1,103 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: invalid_use_of_protected_member
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'iterable_encoder_test.dart';
+
+class FoobarMapper extends ClassMapperBase<Foobar> {
+  FoobarMapper._();
+
+  static FoobarMapper? _instance;
+  static FoobarMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = FoobarMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'Foobar';
+
+  static int _$id(Foobar v) => v.id;
+  static const Field<Foobar, int> _f$id = Field('id', _$id);
+  static String _$name(Foobar v) => v.name;
+  static const Field<Foobar, String> _f$name = Field('name', _$name);
+
+  @override
+  final MappableFields<Foobar> fields = const {#id: _f$id, #name: _f$name};
+
+  static Foobar _instantiate(DecodingData data) {
+    return Foobar(data.dec(_f$id), data.dec(_f$name));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static Foobar fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<Foobar>(map);
+  }
+
+  static Foobar fromJson(String json) {
+    return ensureInitialized().decodeJson<Foobar>(json);
+  }
+}
+mixin FoobarMappable {
+  String toJson() {
+    return FoobarMapper.ensureInitialized().encodeJson<Foobar>(this as Foobar);
+  }
+
+  Map<String, dynamic> toMap() {
+    return FoobarMapper.ensureInitialized().encodeMap<Foobar>(this as Foobar);
+  }
+
+  FoobarCopyWith<Foobar, Foobar, Foobar> get copyWith =>
+      _FoobarCopyWithImpl<Foobar, Foobar>(this as Foobar, $identity, $identity);
+  @override
+  String toString() {
+    return FoobarMapper.ensureInitialized().stringifyValue(this as Foobar);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return FoobarMapper.ensureInitialized().equalsValue(this as Foobar, other);
+  }
+
+  @override
+  int get hashCode {
+    return FoobarMapper.ensureInitialized().hashValue(this as Foobar);
+  }
+}
+
+extension FoobarValueCopy<$R, $Out> on ObjectCopyWith<$R, Foobar, $Out> {
+  FoobarCopyWith<$R, Foobar, $Out> get $asFoobar =>
+      $base.as((v, t, t2) => _FoobarCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class FoobarCopyWith<$R, $In extends Foobar, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({int? id, String? name});
+  FoobarCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _FoobarCopyWithImpl<$R, $Out> extends ClassCopyWithBase<$R, Foobar, $Out>
+    implements FoobarCopyWith<$R, Foobar, $Out> {
+  _FoobarCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<Foobar> $mapper = FoobarMapper.ensureInitialized();
+  @override
+  $R call({int? id, String? name}) => $apply(
+    FieldCopyWithData({if (id != null) #id: id, if (name != null) #name: name}),
+  );
+  @override
+  Foobar $make(CopyWithData data) =>
+      Foobar(data.get(#id, or: $value.id), data.get(#name, or: $value.name));
+
+  @override
+  FoobarCopyWith<$R2, Foobar, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t) =>
+      _FoobarCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}


### PR DESCRIPTION
The iterable encoder is doing that:

```dart
value
    .map((v) => context.$enc<T>(v as T, 'item', context.options))
    .toList();
```

It means that we call the encoder for each item of the iterable.

The problem is that if the iterable is made of primitive types like *int*, *bool*, *String*, etc., the primitive encoder will just return the same value. So for something like a `List<int>`, we still go through the whole encoding logic for every item only to create a new copy of the list with the exact same values.

In this PR, I added a special parameter in the mapper to know if the encoder is an identity encoder or not. If it is, and `context.options` is null, it means we can bypass the `.map()` step and get a significant performance improvement.

On my machine (Mac M4), it was around 20x faster on VM and 10x faster on AOT.

I know that #159 was mentioned to change the architecture and improve performance more globally. I think this could still be an interesting performance improvement in the meantime, especially because the primitive case is very common.
