### PR TITLE
performance: faster equality operation

### DIFF
--- a/packages/dart_mappable/lib/src/mapper_container.dart
+++ b/packages/dart_mappable/lib/src/mapper_container.dart
@@ -266,15 +266,15 @@ class _MapperContainerBase implements MapperContainer, TypeProvider {
 
   MapperBase? _mapperFor(dynamic value) {
     var type = value.runtimeType;
-    if (_cachedMappers[type] != null) {
-      return _cachedMappers[type];
+    if (_cachedMappers[type] case var m?) {
+      return m;
     }
     var baseType = type.base;
     if (baseType == UnresolvedType) {
       baseType = type;
     }
-    if (_cachedMappers[baseType] != null) {
-      return _cachedMappers[baseType];
+    if (_cachedMappers[baseType] case var m?) {
+      return m;
     }
 
     var mapper = //

--- a/packages/dart_mappable/lib/src/mappers/class_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/class_mapper.dart
@@ -246,8 +246,11 @@ abstract class ClassMapperBase<T extends Object>
     if (value.runtimeType.base != other.runtimeType.base) {
       return false;
     }
-    return _members.every((f) {
-      return context.container.isEqual(f.get(value), f.get(other));
-    });
+    for (final f in _members) {
+      if (!context.container.isEqual(f.get(value), f.get(other))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/packages/dart_mappable/lib/src/mappers/class_mapper.dart
+++ b/packages/dart_mappable/lib/src/mappers/class_mapper.dart
@@ -243,9 +243,13 @@ abstract class ClassMapperBase<T extends Object>
 
   @override
   bool equals(T value, T other, MappingContext context) {
-    if (value.runtimeType.base != other.runtimeType.base) {
+    final aType = value.runtimeType;
+    final bType = other.runtimeType;
+
+    if (aType != bType && aType.base != bType.base) {
       return false;
     }
+
     for (final f in _members) {
       if (!context.container.isEqual(f.get(value), f.get(other))) {
         return false;


### PR DESCRIPTION
I was looking at the following [benchark](https://helight.medium.com/benchmarking-darts-json-serialization-and-dataclass-ecosystem-a49969861d08) and I was surprised by the slowness of _dart_mappable_ compared with the other packages during their tests of _indexOf()_ and _==_.

I have run the very same benchark before and after my changes and I have measured a _50%_ improvement on both the _indexOf()_ and _==_ benchmarks.

Three changes:
- The every() method creates a callback that is invoked for each item of the iterable. This is not really a problem for small lists, but on a hot path it starts to become noticeably slower because of the callback overhead. We can already make it faster by simply using a for loop. It is slightly less compact, though -> around 15% faster
- When comparing two objects of the exact same runtime type, we still resolve their base types through _type_plus_ before comparing their fields. This lookup is unnecessary when both runtime types are already equal. Adding a fast path avoids this work while preserving the existing behavior for different generic runtime types -> around 35% faster
- Something that is already done with __mapperForType_. We avoid to get twice the same mapper. -> another 10%